### PR TITLE
Small Performance Improvements

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -977,7 +977,6 @@ impl Repo {
                         fs::create_dir_all(path.parent().unwrap()).unwrap();
                         let mut chunk_file = fs::File::create(&tmp_path).unwrap();
                         chunk_file.write_all(&data).unwrap();
-                        chunk_file.sync_data().unwrap();
                         drop(chunk_file);
                         fs::rename(&tmp_path, &path).unwrap();
                     }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -29,7 +29,7 @@ use crypto::digest::Digest;
 use sodiumoxide::crypto::{box_, pwhash, secretbox};
 
 const BUFFER_SIZE: usize = 16 * 1024;
-const CHANNEL_SIZE: usize = 1024;
+const CHANNEL_SIZE: usize = 128;
 
 const REPO_VERSION_LOWEST: u32 = 0;
 const REPO_VERSION_CURRENT: u32 = 0;


### PR DESCRIPTION
These small changes lead to some tangible performance improvements when using rdedup. I tested the changes using my Projects folder housing 3.36GB of git project data on my mac to a HDD attached via USB 3.0

These improvements lead to a 20% reduction in backup time and a 90% reduction in memory consumption when running the program. I ran the master and this version 3 times each to get a small benchmark dataset. Your mileage may vary.

Reducing the Channel size for the 4 changes from 1024 to 128 was the big improvement to memory consumption.

Removing the ```chunk_file.sync_data().unwrap()``` call reduced the processing time as the drop following the statement closes the file and flushes it anyways resulting in a double fsync. I have tested the integrity of the data being backed up and I had consistent data on restore.