### PR TITLE
Deferred data_sync and renaming to optimize drive writes

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1000,41 +1000,42 @@ impl Repo {
     }
 
     fn chunk_writer(&self, rx: mpsc::Receiver<ChunkMessage>) {
-        let mut queue: VecDeque<(PathBuf, PathBuf, File)> = VecDeque::with_capacity(CHANNEL_SIZE);
+        let mut queue: VecDeque<(File)> = VecDeque::with_capacity(CHANNEL_SIZE);
         // Cache paths to make sure we don't queue up an existing block
         let mut queue_paths: HashSet<PathBuf> = HashSet::new();
 
-        fn flush(queue: &VecDeque<(PathBuf, PathBuf, File)>) {
-            for &(_, _, ref chunk_file) in queue.iter() {
-                chunk_file.sync_data().unwrap();
-                drop(chunk_file);
+        fn flush(queue: &mut VecDeque<File>, queue_paths: &mut HashSet<PathBuf>) {
+            while let Some(file) = queue.pop_front() {
+                file.sync_data().unwrap();
             }
             // Run renames after data sync to mitigate data writes and metadata writes contention
-            for &(ref path, ref tmp_path, _) in queue.iter() {
+            let mut drain = queue_paths.drain();
+            while let Some(path) = drain.next() {
+                let tmp_path = path.with_extension("tmp");
                 fs::rename(&tmp_path, &path).unwrap();
             }
         }
         loop {
             match rx.recv().unwrap() {
                 ChunkMessage::Exit => {
-                    flush(&queue);
+                    flush(&mut queue, &mut queue_paths);
                     return;
                 }
                 ChunkMessage::Data(data, sha256, chunk_type, _) => {
                     let path = self.chunk_path_by_digest(&sha256, chunk_type);
                     if !queue_paths.contains(&path) && !path.exists() {
+                        if queue.len() == CHANNEL_SIZE {
+                            flush(&mut queue, &mut queue_paths);
+                        }
+
                         let tmp_path = path.with_extension("tmp");
                         fs::create_dir_all(path.parent().unwrap()).unwrap();
                         let mut chunk_file = fs::File::create(&tmp_path).unwrap();
                         chunk_file.write_all(&data).unwrap();
 
                         // Queue chunk up for data sync and rename
-                        queue_paths.insert(path.clone());
-                        queue.push_back((path, tmp_path, chunk_file));
-                        if queue.len() == CHANNEL_SIZE {
-                            flush(&mut queue);
-                            queue.clear();
-                        }
+                        queue_paths.insert(path);
+                        queue.push_back(chunk_file);
                     }
                 }
             }


### PR DESCRIPTION
As per our discussions on PR #29 this is another method of optimizing the write performance of rdedup.

We maintain the data_sync completion before renaming the chunk into its final position but we write the data out and queue up the syncing to happen after the queue has grow to ```CHANNEL_SIZE```. Once grown we sync data in the first pass then rename in the second to avoid data sync and metadata write contentions. We are also caching what paths are queue for syncing / renaming so we don't try to write out the same data again and avoid a race condition on the renaming. Currently we cache all the paths written during the store but I can had a clear after the flush to keep it the same size as the queue at all times if memory is of concern.

To test the performance gains I tar my projects folder with 1.9 GB worth of git projects and then piped it into a fresh repo as a worst case scenario.

The result with running a 2 different drives 3 rounds each are:

**Faster HDD**
Original Method: 91 seconds
New Method: 78 seconds
Improvement: 14%

**Slower HDD**
Original Method: 192 seconds
New Method: 121 seconds
Improvement: 37%

*The times are the median of the three runs*
