### PR TITLE
Release 1.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdedup"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>"]
 description = "Data deduplication with compression and public key encryption. - binary"
 keywords = ["data", "backup", "dedupliation", "encryption", "dedup"]
@@ -16,7 +16,7 @@ name = "rdedup"
 path = "src/bin.rs"
 
 [dependencies]
-rdedup-lib = { version = "1.0.0", path = "lib" }
+rdedup-lib = { version = "1.0.1", path = "lib" }
 log = "0.3.6"
 rustc-serialize = "0.3.19"
 argparse = "0.2.1"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdedup-lib"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>"]
 description = "Data deduplication with compression and public key encryption. - library"
 keywords = ["data", "backup", "dedupliation", "encryption", "dedup"]


### PR DESCRIPTION
As per #42 this PR bumps up the version number of the lib and bin crates to 1.0.1. This matches the code released to crates.io