### PR TITLE
Support verify of name

### DIFF
--- a/lib/src/tests.rs
+++ b/lib/src/tests.rs
@@ -235,7 +235,7 @@ fn verify_name() {
     }
 
     let mut result = repo.verify("data", &seckey).unwrap();
-    assert_eq!(result.corrupted.len(), 0);
+    assert_eq!(result.errors.len(), 0);
 
     // Corrupt first chunk we find
     let chunk_path = dir_path.join("chunk");
@@ -260,7 +260,7 @@ fn verify_name() {
     }
 
     result = repo.verify("data", &seckey).unwrap();
-    assert_eq!(result.corrupted.len(), 1);
+    assert_eq!(result.errors.len(), 1);
 
     wipe(&repo);
 }

--- a/lib/src/tests.rs
+++ b/lib/src/tests.rs
@@ -261,4 +261,6 @@ fn verify_name() {
 
     result = repo.verify("data", &seckey).unwrap();
     assert_eq!(result.corrupted.len(), 1);
+
+    wipe(&repo);
 }

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -278,9 +278,9 @@ fn run(options: &Options) -> io::Result<()> {
 
             let results = try!(repo.verify(&name, &seckey));
             println!("scanned {} chunk(s)", results.scanned);
-            println!("found {} corrupted chunk(s)", results.corrupted.len());
-            for chunk in results.corrupted.into_iter() {
-                println!("chunk {} corrupted", &chunk.to_hex());
+            println!("found {} corrupted chunk(s)", results.errors.len());
+            for err in results.errors.into_iter() {
+                println!("chunk {} - {}", &err.0.to_hex(), err.1);
             }
         }
     }


### PR DESCRIPTION
Added support to library and binary to verify the integrity of a name. When completed the list of chunks that are corrupt are returned.

Closes #7.