### PR TITLE
Add more stats output to rdedup commands

### DIFF
--- a/lib/src/tests.rs
+++ b/lib/src/tests.rs
@@ -187,7 +187,7 @@ fn random_sanity() {
 
         assert_eq!(stored_after_rm.len(), stored.len());
         assert!(reachable_after_rm.len() < reachable.len());
-        assert!(repo.gc().unwrap() > 0);
+        assert!(repo.gc().unwrap().chunks > 0);
     }
 
     wipe(&repo);

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -248,8 +248,9 @@ fn run(options: &Options) -> io::Result<()> {
             let pass = read_passphrase(&options);
             let seckey = try!(repo.get_seckey(&pass));
 
-            let size = try!(repo.du(&name, &seckey));
-            println!("{}", size);
+            let result = try!(repo.du(&name, &seckey));
+            println!("{} chunks", result.chunks);
+            println!("{} bytes", result.bytes);
         }
         Command::GC => {
             options.check_no_arguments();

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -210,7 +210,9 @@ fn run(options: &Options) -> io::Result<()> {
             let name = options.check_name();
             let dir = options.check_dir();
             let repo = try!(Repo::open(&dir));
-            try!(repo.write(&name, &mut io::stdin()));
+            let stats = try!(repo.write(&name, &mut io::stdin()));
+            println!("{} new chunks", stats.new_chunks);
+            println!("{} new bytes", stats.new_bytes);
         }
         Command::Load => {
             let name = options.check_name();

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -257,8 +257,9 @@ fn run(options: &Options) -> io::Result<()> {
 
             let repo = try!(Repo::open(&dir));
 
-            let removed = try!(repo.gc());
-            println!("Removed {} chunks", removed);
+            let result = try!(repo.gc());
+            println!("Removed {} chunks", result.chunks);
+            println!("Freed {} bytes", result.bytes);
         }
         Command::List => {
             options.check_no_arguments();


### PR DESCRIPTION
This closes #31.

Added additional statistic outputs to the du, gc, and store commands.

### du:
- added line about number of chunks represented in the name

### gc:
- added line about number of bytes freed by the operation

### store:
- added line about number of new bytes written
- added line about number of new chunks written