### PR TITLE
Improve gc processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Missing "changepassphrase" command to rdedup
 - Improved stats to store, du, gc api calls and commands
 - Changelog to repository
+- Optimized GC to use an iterator of stored chunks instead of an in memory set
 
 # v1.0.1
 ## Added

--- a/lib/src/iterators.rs
+++ b/lib/src/iterators.rs
@@ -1,0 +1,81 @@
+use serialize::hex::FromHex;
+
+use std::fs;
+use std::fs::ReadDir;
+use std::io::Result;
+use std::path::Path;
+
+pub struct StoredChunks {
+    dir: ReadDir,
+    next_level: Option<Box<StoredChunks>>,
+    digest_size: usize,
+}
+
+impl StoredChunks {
+    pub fn new(root: &Path, digest_size: usize) -> Result<StoredChunks> {
+        Ok(StoredChunks {
+            dir: try!(fs::read_dir(root)),
+            next_level: None,
+            digest_size: digest_size,
+        })
+    }
+}
+
+impl Iterator for StoredChunks {
+    type Item = Result<Vec<u8>>;
+
+    fn next(&mut self) -> Option<Result<Vec<u8>>> {
+        // Check if we have an iterator for the next level, if so we process from that iterator.
+        let is_some = self.next_level.is_some();
+        if is_some {
+            let val: Option<Result<Vec<u8>>>;
+            {
+                val = self.next_level.as_mut().unwrap().next();
+            }
+            match val {
+                Some(v) => return Some(v),
+                None => self.next_level = None,
+            };
+        }
+        // There was either no next_level or next_level is now exhausted, move our directory
+        // iterator forward
+        let dir_res = self.dir.next();
+        if dir_res.is_none() {
+            return None;
+        }
+        let entry = match dir_res.unwrap() {
+            Ok(e) => e,
+            Err(err) => return Some(Err(err)),
+        };
+        let entry_path = entry.path();
+        trace!("Looking at {}", entry_path.to_string_lossy());
+        if entry_path.is_dir() {
+            // We hit a directory lets get a new StoredChunks iterator for that level and exhaust it.
+            let next_level = match StoredChunks::new(&entry_path, self.digest_size) {
+                Ok(sc) => sc,
+                Err(e) => return Some(Err(e)),
+            };
+
+            self.next_level = Some(Box::new(next_level));
+            return self.next();
+        }
+        // We have landed on a file, we need to verify the file is a valid chunk by parsing the hex
+        // code in the file name.
+        let name = entry.file_name().to_string_lossy().to_string();
+        match name.from_hex() {
+            Ok(digest) => {
+                if digest.len() == self.digest_size {
+                    return Some(Ok(digest));
+                } else {
+                    trace!("skipping {}", entry_path.to_string_lossy());
+                    // Maybe we should remove this file? It is not a valid chunk file.
+                    return self.next();
+                }
+            }
+            Err(e) => {
+                trace!("skipping {}, error {}", entry_path.to_string_lossy(), e);
+                return self.next();
+            }
+        }
+    }
+}

--- a/lib/src/iterators.rs
+++ b/lib/src/iterators.rs
@@ -5,7 +5,8 @@ use std::fs::ReadDir;
 use std::io::Result;
 use std::path::Path;
 
-/// StoredChunks is an iterator for the list of chunks stored for indexes and data in the repo.
+/// StoredChunks is an iterator for the list of chunks stored in a path, it will crawl the directory
+/// structure looking for chunks that have valid digest sized elements as their name.
 /// Invalid files with incorrect names will be ignored.
 pub struct StoredChunks {
     dirs: Vec<ReadDir>,

--- a/lib/src/iterators.rs
+++ b/lib/src/iterators.rs
@@ -48,7 +48,6 @@ impl Iterator for StoredChunks {
                 Ok(sc) => Some(Box::new(sc)),
                 Err(e) => return Some(Err(e)),
             };
-
             return self.next();
         }
         // We have landed on a file, we need to verify the file is a valid chunk by parsing the hex
@@ -58,16 +57,12 @@ impl Iterator for StoredChunks {
             Ok(digest) => {
                 if digest.len() == self.digest_size {
                     return Some(Ok(digest));
-                } else {
-                    trace!("skipping {}", entry_path_str);
-                    // Maybe we should remove this file? It is not a valid chunk file.
-                    return self.next();
                 }
+                trace!("skipping {}", entry_path_str);
+                // Maybe we should remove this file? It is not a valid chunk file.
             }
-            Err(e) => {
-                trace!("skipping {}, error {}", entry_path_str, e);
-                return self.next();
-            }
+            Err(e) => trace!("skipping {}, error {}", entry_path_str, e),
         }
+        return self.next();
     }
 }

--- a/lib/src/iterators.rs
+++ b/lib/src/iterators.rs
@@ -5,17 +5,17 @@ use std::fs::ReadDir;
 use std::io::Result;
 use std::path::Path;
 
+/// StoredChunks is an iterator for the list of chunks stored for indexes and data in the repo.
+/// Invalid files with incorrect names will be ignored.
 pub struct StoredChunks {
-    dir: ReadDir,
-    next_level: Option<Box<StoredChunks>>,
+    dirs: Vec<ReadDir>,
     digest_size: usize,
 }
 
 impl StoredChunks {
     pub fn new(root: &Path, digest_size: usize) -> Result<StoredChunks> {
         Ok(StoredChunks {
-            dir: try!(fs::read_dir(root)),
-            next_level: None,
+            dirs: vec![fs::read_dir(root)?],
             digest_size: digest_size,
         })
     }
@@ -25,44 +25,39 @@ impl Iterator for StoredChunks {
     type Item = Result<Vec<u8>>;
 
     fn next(&mut self) -> Option<Result<Vec<u8>>> {
-        // Check if we have an iterator for the next level, if so we process from that iterator.
-        if self.next_level.is_some() {
-            match self.next_level.as_mut().unwrap().next() {
-                Some(v) => return Some(v),
-                None => self.next_level = None,
-            };
-        }
-        // There was either no next_level or next_level is now exhausted, move our directory
-        // iterator forward
-        let entry = match self.dir.next() {
-            Some(Ok(entry)) => entry,
-            Some(Err(error)) => return Some(Err(error)),
-            None => return None,
-        };
-        let entry_path = entry.path();
-        let entry_path_str = entry_path.to_string_lossy();
-        trace!("Looking at {}", entry_path_str);
-        if entry_path.is_dir() {
-            // We hit a directory lets get a new StoredChunks iterator for that level and exhaust it.
-            self.next_level = match StoredChunks::new(&entry_path, self.digest_size) {
-                Ok(sc) => Some(Box::new(sc)),
-                Err(e) => return Some(Err(e)),
-            };
-            return self.next();
-        }
-        // We have landed on a file, we need to verify the file is a valid chunk by parsing the hex
-        // code in the file name.
-        let name = entry.file_name().to_string_lossy().to_string();
-        match name.from_hex() {
-            Ok(digest) => {
-                if digest.len() == self.digest_size {
-                    return Some(Ok(digest));
+        while self.dirs.len() > 0 {
+            let entry = match self.dirs.last_mut().unwrap().next() {
+                Some(Ok(entry)) => entry,
+                Some(Err(error)) => return Some(Err(error)),
+                None => {
+                    self.dirs.pop();
+                    continue;
                 }
-                trace!("skipping {}", entry_path_str);
-                // Maybe we should remove this file? It is not a valid chunk file.
+            };
+            let entry_path = entry.path();
+            let entry_path_str = entry_path.to_string_lossy();
+            trace!("Looking at {}", entry_path_str);
+            if entry_path.is_dir() {
+                match fs::read_dir(&entry_path) {
+                    Ok(entries) => self.dirs.push(entries),
+                    Err(e) => return Some(Err(e)),
+                }
+                continue;
             }
-            Err(e) => trace!("skipping {}, error {}", entry_path_str, e),
+            // We have landed on a file, we need to verify the file is a valid chunk by parsing the hex
+            // code in the file name.
+            let name = entry.file_name().to_string_lossy().to_string();
+            match name.from_hex() {
+                Ok(digest) => {
+                    if digest.len() == self.digest_size {
+                        return Some(Ok(digest));
+                    }
+                    trace!("skipping {}", entry_path_str);
+                    // Maybe we should remove this file? It is not a valid chunk file.
+                }
+                Err(e) => trace!("skipping {}, error {}", entry_path_str, e),
+            }
         }
-        return self.next();
+        None
     }
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -29,6 +29,8 @@ use crypto::digest::Digest;
 
 use sodiumoxide::crypto::{box_, pwhash, secretbox};
 
+mod iterators;
+
 const BUFFER_SIZE: usize = 16 * 1024;
 const CHANNEL_SIZE: usize = 128;
 const DIGEST_SIZE: usize = 32;
@@ -1211,42 +1213,10 @@ impl Repo {
     fn list_stored_chunks(&self) -> Result<HashSet<Vec<u8>>> {
         info!("List stored chunks");
         fn insert_all_digest(path: &Path, reachable: &mut HashSet<Vec<u8>>) {
-            trace!("Looking in {}", path.to_string_lossy());
-            for out_entry in fs::read_dir(path).unwrap() {
-                let out_entry = out_entry.unwrap();
-                let out_entry_path = out_entry.path();
-                if !out_entry_path.is_dir() {
-                    trace!("skipping {}", out_entry_path.to_string_lossy());
-                    continue;
-                }
-                trace!("Looking in {}", out_entry_path.to_string_lossy());
-                for mid_entry in fs::read_dir(out_entry_path).unwrap() {
-                    let mid_entry = mid_entry.unwrap();
-                    let mid_entry_path = mid_entry.path();
-                    if !mid_entry_path.is_dir() {
-                        trace!("skipping {}", mid_entry_path.to_string_lossy());
-                        continue;
-                    }
-                    trace!("Looking in {}", mid_entry.path().to_string_lossy());
-                    for entry in fs::read_dir(mid_entry_path).unwrap() {
-                        let entry = entry.unwrap();
-                        let entry_path = entry.path();
-                        trace!("Looking in {}", entry_path.to_string_lossy());
-                        let name = entry.file_name().to_string_lossy().to_string();
-                        match name.from_hex() {
-                            Ok(digest) => {
-                                if digest.len() == DIGEST_SIZE {
-                                    reachable.insert(digest);
-                                } else {
-                                    trace!("skipping {}", entry_path.to_string_lossy());
-                                }
-                            }
-                            Err(e) => {
-                                trace!("skipping {}, error {}", entry_path.to_string_lossy(), e);
-                            }
-                        }
-                    }
-                }
+            let dirs = iterators::StoredChunks::new(path, DIGEST_SIZE).unwrap();
+            for digest in dirs {
+                let val = digest.unwrap();
+                reachable.insert(val);
             }
         }
 


### PR DESCRIPTION
This is part of #32.

Created an iterator for the stored chunks that can be flexible in the number of levels needing to be processed. In preparation for #43.

This also improves the gc process because we only maintain the list of reachable chunks in a set in memory then use that to compare each chunk from the iterator to determine if it is still valid.

I moved the code to a separate file to make it easier to know where the iterator is. In the future I plan to use more iterators as it allows for us to take advantage of functions like map, reduce, filter, etc to improve the core legibility of the lib code. An example could be the chunk accessors or the chunker.

Let me know if you would rather I just move the code into lib.rs. 

Anyway this is my last PR for 2016 so happy new years! Lets see what we can do in 2017 ;)