### PR TITLE
Force Rebuild of Clippy to match nightly build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
 - export PKG_CONFIG_PATH=$HOME/installed_libsodium/lib/pkgconfig:$PKG_CONFIG_PATH
 - export LD_LIBRARY_PATH=$HOME/installed_libsodium/lib:$LD_LIBRARY_PATH
 - if [ ! -x ~/.cargo/bin/cargo-fmt ]; then cargo install rustfmt; fi
-- if [ ! -x ~/.cargo/bin/cargo-clippy ]; then cargo install clippy; fi
+- cargo install -f clippy
 - ls -ahl ~/.cargo/bin/
 
 notifications:


### PR DESCRIPTION
Clippy is closely linked to the version of nightly that it is running against so in order for our CI builds to be properly linted we need to always rebuild clippy.