### PR TITLE
Added support for customizing the chunking algorithm bit size.

### DIFF
--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -231,12 +231,12 @@ pub enum ChunkingAlogrithm {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-/// RepoChunking is the configuration of the chunking algorithm and parameters for the repo
+/// ```RepoChunking``` is the configuration of the chunking algorithm and parameters for the repo
 pub struct RepoChunking {
     pub algorithm: ChunkingAlogrithm,
     pub size: u32, // size is generic enough to work with different algorithms
 }
-/// Default implementation for the RepoChunking structure
+/// Default implementation for the ```RepoChunking``` structure
 impl Default for RepoChunking {
     fn default() -> RepoChunking {
         RepoChunking {

--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -227,8 +227,8 @@ pub struct Curve25519 {
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq)]
 /// ```ChunkingAlgorithm``` are the algorithms supported by rdedup
 pub enum ChunkingAlgorithm {
-    /// ```Bup``` is the default algorithm, the chunk_bits value provided with bup is the bit mask
-    ///size to be used by rollsum. The valid range is between 10 and 30 (1KB to 1GB)
+    /// ```Bup``` is the default algorithm, the chunk_bits value provided with bup is the bit shift
+    ///to be used by rollsum. The valid range is between 10 and 30 (1KB to 1GB)
     Bup { chunk_bits: u32 },
 }
 /// Default implementation for the ```ChunkingAlgorithm```

--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -227,21 +227,21 @@ pub struct Curve25519 {
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq)]
 /// ```ChunkingAlgorithm``` are the algorithms supported by rdedup
 pub enum ChunkingAlgorithm {
-    /// ```Bup``` is the default algorithm, the u32 value provided with bup is the bit mask size to
-    /// be used by rollsum. The valid range is between 10 and 30 (1KB to 1GB)
-    Bup(u32),
+    /// ```Bup``` is the default algorithm, the chunk_bits value provided with bup is the bit mask
+    ///size to be used by rollsum. The valid range is between 10 and 30 (1KB to 1GB)
+    Bup { chunk_bits: u32 },
 }
 /// Default implementation for the ```ChunkingAlgorithm```
 impl Default for ChunkingAlgorithm {
     fn default() -> ChunkingAlgorithm {
-        ChunkingAlgorithm::Bup(17)
+        ChunkingAlgorithm::Bup { chunk_bits: 17 }
     }
 }
 
 impl ChunkingAlgorithm {
     pub fn valid(self) -> bool {
         match self {
-            ChunkingAlgorithm::Bup(bits) => 30 >= bits && bits >= 10,
+            ChunkingAlgorithm::Bup { chunk_bits: bits } => 30 >= bits && bits >= 10,
         }
     }
 }

--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -107,7 +107,8 @@ pub fn write_config_v0(repo_path: &Path,
 pub fn write_config_v1(repo_path: &Path,
                        pk: &box_::PublicKey,
                        sk: &box_::SecretKey,
-                       passphrase: &str)
+                       passphrase: &str,
+                       chunking: RepoChunking)
                        -> super::Result<()> {
 
     let salt = pwhash::gen_salt();
@@ -127,6 +128,7 @@ pub fn write_config_v1(repo_path: &Path,
             nonce: nonce,
             salt: salt,
         }),
+        chunking: Some(chunking),
     };
 
     let config_str = serde_yaml::to_string(&config).expect("yaml serialization failed");
@@ -215,6 +217,28 @@ pub struct RepoEncryption {
     pub nonce: secretbox::Nonce,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+/// Chunking Algorithms supported by rdedup
+pub enum ChunkingAlogrithm {
+    Bup,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+/// RepoChunking is the configuration of the chunking algorithm and parameters for the repo
+pub struct RepoChunking {
+    pub algorithm: ChunkingAlogrithm,
+    pub size: u32, // size is generic enough to work with different algorithms
+}
+/// Default implementation for the RepoChunking structure
+impl Default for RepoChunking {
+    fn default() -> RepoChunking {
+        RepoChunking {
+            algorithm: ChunkingAlogrithm::Bup,
+            size: 17,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize)]
 /// Rdedup repository configuration
 ///
@@ -223,4 +247,5 @@ pub struct RepoEncryption {
 pub struct Repo {
     pub version: u32,
     pub encryption: Option<RepoEncryption>,
+    pub chunking: Option<RepoChunking>,
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -189,7 +189,7 @@ fn chunk_and_send_to_assembler<R: Read>(tx: &mpsc::SyncSender<ChunkAssemblerMess
                                         chunking_algo: ChunkingAlgorithm)
                                         -> Result<Vec<u8>> {
     let chunk_bits = match chunking_algo {
-        ChunkingAlgorithm::Bup(bits) => bits,
+        ChunkingAlgorithm::Bup { chunk_bits: bits } => bits,
     };
     let mut chunker = Chunker::new(chunk_bits);
 
@@ -657,7 +657,7 @@ impl Repo {
         // Validate ChunkingAlgorithm
         if !chunking.valid() {
             return Err(Error::new(io::ErrorKind::InvalidInput,
-                                  format!("invalid chunking algorithm defined")));
+                                  "invalid chunking algorithm defined"));
         }
 
         let (pk, sk) = box_::gen_keypair();

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -79,7 +79,7 @@ type Edge = (usize, Vec<u8>);
 
 /// Finds edges using rolling sum
 struct Chunker {
-    bits: u32,
+    chunk_bits: u32,
     roll: rollsum::Bup,
     sha256: sha2::Sha256,
     bytes_total: usize,
@@ -92,7 +92,7 @@ struct Chunker {
 impl Chunker {
     pub fn new(chunk_bits: u32) -> Self {
         Chunker {
-            bits: chunk_bits,
+            chunk_bits: chunk_bits,
             roll: rollsum::Bup::new_with_chunk_bits(chunk_bits),
             sha256: sha2::Sha256::new(),
             bytes_total: 0,
@@ -116,7 +116,7 @@ impl Chunker {
         self.bytes_chunk = 0;
 
         self.sha256.reset();
-        self.roll = rollsum::Bup::new_with_chunk_bits(self.bits);
+        self.roll = rollsum::Bup::new_with_chunk_bits(self.chunk_bits);
     }
 
     pub fn input(&mut self, buf: &[u8]) -> Vec<Edge> {

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -39,7 +39,7 @@ use sodiumoxide::crypto::{box_, pwhash, secretbox};
 mod iterators;
 use iterators::StoredChunks;
 
-mod config;
+pub mod config;
 
 const BUFFER_SIZE: usize = 16 * 1024;
 const CHANNEL_SIZE: usize = 128;

--- a/lib/src/tests.rs
+++ b/lib/src/tests.rs
@@ -366,7 +366,7 @@ fn test_custom_chunking_size() {
     for bits in [9, 10, 17, 20, 30, 31].iter() {
         let bits = *bits;
         let dir_path = rand_tmp_dir();
-        let chunking = ChunkingAlgorithm::Bup(bits);
+        let chunking = ChunkingAlgorithm::Bup { chunk_bits: bits };
         {
 
             let result = lib::Repo::init(&dir_path, PASS, chunking.clone());

--- a/lib/src/tests.rs
+++ b/lib/src/tests.rs
@@ -3,7 +3,7 @@ mod lib {
 }
 
 use iterators::StoredChunks;
-use config::{ChunkingAlogrithm, RepoChunking};
+use config::ChunkingAlgorithm;
 
 use std::collections::HashSet;
 use std::path;
@@ -115,7 +115,7 @@ fn wipe(repo: &lib::Repo) {
 
 #[test]
 fn zero_size() {
-    let repo = lib::Repo::init(&rand_tmp_dir(), PASS, RepoChunking::default()).unwrap();
+    let repo = lib::Repo::init(&rand_tmp_dir(), PASS, ChunkingAlgorithm::default()).unwrap();
 
     let seckey = repo.get_seckey(PASS).unwrap();
 
@@ -132,7 +132,7 @@ fn zero_size() {
 
 #[test]
 fn byte_size() {
-    let repo = lib::Repo::init(&rand_tmp_dir(), PASS, RepoChunking::default()).unwrap();
+    let repo = lib::Repo::init(&rand_tmp_dir(), PASS, ChunkingAlgorithm::default()).unwrap();
     let seckey = repo.get_seckey(PASS).unwrap();
     let tests = [0u8, 1, 13, 255];
     for &b in &tests {
@@ -154,7 +154,7 @@ fn byte_size() {
 fn random_sanity() {
     let mut names = vec![];
 
-    let repo = lib::Repo::init(&rand_tmp_dir(), PASS, RepoChunking::default()).unwrap();
+    let repo = lib::Repo::init(&rand_tmp_dir(), PASS, ChunkingAlgorithm::default()).unwrap();
     let seckey = repo.get_seckey(PASS).unwrap();
     for i in 0..10 {
         let mut data = ExampleDataGen::new(rand::weak_rng().gen_range(0, 10 * 1024));
@@ -217,7 +217,8 @@ fn change_passphrase() {
     let data_before = rand_data(1024);
 
     {
-        let repo = lib::Repo::init(dir_path, prev_passphrase, RepoChunking::default()).unwrap();
+        let repo = lib::Repo::init(dir_path, prev_passphrase, ChunkingAlgorithm::default())
+            .unwrap();
         repo.write("data", &mut io::Cursor::new(&data_before)).unwrap();
     }
 
@@ -245,7 +246,7 @@ fn change_passphrase() {
 #[test]
 fn verify_name() {
     let dir_path = rand_tmp_dir();
-    let repo = lib::Repo::init(&dir_path, PASS, RepoChunking::default()).unwrap();
+    let repo = lib::Repo::init(&dir_path, PASS, ChunkingAlgorithm::default()).unwrap();
     let seckey = repo.get_seckey(PASS).unwrap();
     let data = rand_data(1024);
     {
@@ -319,7 +320,7 @@ fn migration_v0_to_v1() {
 #[test]
 fn test_stored_chunks_iter() {
     let dir_path = rand_tmp_dir();
-    let repo = lib::Repo::init(&dir_path, PASS, RepoChunking::default()).unwrap();
+    let repo = lib::Repo::init(&dir_path, PASS, ChunkingAlgorithm::default()).unwrap();
     let data = rand_data(1024 * 1024);
 
     repo.write("data", &mut io::Cursor::new(&data)).unwrap();
@@ -362,16 +363,25 @@ fn test_stored_chunks_iter() {
 
 #[test]
 fn test_custom_chunking_size() {
-    let dir_path = rand_tmp_dir();
-    let chunking = RepoChunking {
-        algorithm: ChunkingAlogrithm::Bup,
-        size: 20,
-    };
-    {
-        lib::Repo::init(&dir_path, PASS, chunking.clone()).unwrap();
+    for bits in [9, 10, 17, 20, 30, 31].iter() {
+        let bits = *bits;
+        let dir_path = rand_tmp_dir();
+        let chunking = ChunkingAlgorithm::Bup(bits);
+        {
+
+            let result = lib::Repo::init(&dir_path, PASS, chunking.clone());
+            if bits < 10 || bits > 30 {
+                if result.is_err() {
+                    continue;
+                } else {
+                    panic!("expected an error for value {:}, but got Ok", bits);
+                }
+            } else if result.is_err() {
+                panic!("expected Ok, but got {:}", result.err().unwrap());
+            }
+        }
+        let repo = lib::Repo::open(&dir_path).unwrap();
+        assert_eq!(chunking, repo.chunking);
+        wipe(&repo);
     }
-    let repo = lib::Repo::open(&dir_path).unwrap();
-    assert_eq!(chunking.algorithm, repo.chunking.algorithm);
-    assert_eq!(chunking.size, repo.chunking.size);
-    wipe(&repo);
 }

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -76,7 +76,7 @@ fn parse_size(input: &str) -> Option<u64> {
         return None;
     }
 
-    let units = ["K", "M", "G", "T"];
+    let units = ["K", "M", "G", "T", "P", "E"];
     let unit = input.matches(char::is_alphabetic).next();
     let str_size: String = input.matches(char::is_numeric).collect();
 
@@ -93,6 +93,8 @@ fn parse_size(input: &str) -> Option<u64> {
         if let Some(idx) = units.iter().position(|&u| u == unit) {
             let modifier: u64 = 1024u64.pow(idx as u32 + 1);
             size *= modifier;
+        } else {
+            return None;
         }
     }
     Some(size)
@@ -100,24 +102,20 @@ fn parse_size(input: &str) -> Option<u64> {
 
 #[test]
 fn test_parse_size() {
-    // tuples that are str, expected u64, pass or fail
-    let tests = [("192K", 192 * 1024, true),
-                 ("1M", 1024u64.pow(2), true),
-                 ("Hello", 0, false),
-                 ("12345.6789", 0, false),
-                 ("1024B", 1024, true), // Passes because we ignore unknown suffixes
-                 ("1024P", 1024, true), // Passes because we ignore unknown suffixes
-                 ("1t", 1024u64.pow(4), true)];
+    // tuples that are str, expected Option<u64>
+    let tests = [("192K", Some(192 * 1024)),
+                 ("1M", Some(1024u64.pow(2))),
+                 ("Hello", None),
+                 ("12345.6789", None),
+                 ("1024B", None),
+                 ("1024A", None),
+                 ("1t", Some(1024u64.pow(4))),
+                 ("1E", Some(1024u64.pow(6)))];
 
     for test in &tests {
-        if let Some(value) = parse_size(test.0) {
-            if !test.2 {
-                panic!("test {:} should of failed but did not, value: {:}", test.0, value);
-            } else if test.1 != value {
-                panic!("expected {:}, got {:}", test.1, value);
-            }
-        } else if test.2 {
-            panic!("test {:} failed when it shouldn't have", test.0);
+        let result = parse_size(test.0);
+        if result != test.1 {
+            panic!("expected {:?}, got {:?}", test.1, result);
         }
     }
 }

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -161,7 +161,7 @@ impl Options {
             ap.refer(&mut chunking)
                 .add_option(&["--chunking"], Store, "chunking algorithm (bup - default)");
             ap.refer(&mut chunk_size)
-                .add_option(&["--chunk_size"], Store, "chunking size, default: 128k");
+                .add_option(&["--chunk-size"], Store, "chunking size, default: 128k");
             ap.refer(&mut command)
                 .add_argument("command", Store, r#"command to run"#);
             ap.refer(&mut args)

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -250,7 +250,7 @@ impl Options {
                     printerrln!("invalid chunk size provided for bup, must be power of 2");
                     process::exit(-1);
                 }
-                let algo = ChunkingAlgorithm::Bup(size.trailing_zeros());
+                let algo = ChunkingAlgorithm::Bup { chunk_bits: size.trailing_zeros() };
                 if !algo.valid() {
                     printerrln!("invalid chunk size, value must be at least 1K and no more then \
                                  1G");

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -252,12 +252,13 @@ impl Options {
                     printerrln!("invalid chunk size provided for bup, must be power of 2");
                     process::exit(-1);
                 }
-                if 1024 > size || size > 1024u64.pow(3) {
+                let algo = ChunkingAlgorithm::Bup(size.trailing_zeros());
+                if !algo.valid() {
                     printerrln!("invalid chunk size, value must be at least 1K and no more then \
                                  1G");
                     process::exit(-1);
                 }
-                ChunkingAlgorithm::Bup(size.trailing_zeros())
+                algo
             }
             _ => {
                 printerrln!("chunking algorithm {:} not supported", self.chunking);


### PR DESCRIPTION
Closes #40.

This MR adds support for custom bitsize settings for the bup chunking algorithm. The configuration is defined in a way to support more algorithms in the future.

What should the command line configuration be? I was thinking:
```rdedup init --chunking bup:17```

Or maybe:
```rdedup init --bup=17```

What do you think @dpc?

I will make additional commits once we determine the commandline arguments to use.