### PR TITLE
Use unwrap_or_default to simplfy code

### DIFF
--- a/src/bin.rs
+++ b/src/bin.rs
@@ -168,10 +168,7 @@ struct Options {
 
 impl Options {
     fn new() -> Self {
-        // TODO: When stable we should use unwrap_or_default() instead
-        // See https://github.com/rust-lang/rust/issues/37516
-        let mut dir_str: String =
-            env::var("RDEDUP_DIR").unwrap_or_else(|_| "".to_owned());
+        let mut dir_str: String = env::var("RDEDUP_DIR").unwrap_or_default();
         let mut args = vec![];
         let mut command = Command::Help;
         let mut usage = vec![];


### PR DESCRIPTION
Just a simple line cleanup. I just remembered it when I read the 1.16 rust announcement from the newsletter.