### PR TITLE
Replace rust-crypto with sha2 crate

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/lib.rs"
 
 [dependencies]
 rollsum = "0.2.1"
-rust-crypto = "0.2"
+sha2 = "0.5"
 rustc-serialize = "0.3.19"
 argparse = "0.2.1"
 sodiumoxide = { version = "0.0.14", features = ["serde"] }

--- a/lib/src/sg.rs
+++ b/lib/src/sg.rs
@@ -3,11 +3,10 @@
 
 use DIGEST_SIZE;
 use DataType;
-use crypto::digest::Digest;
+use sha2::{Sha256, Digest};
 use flate2;
 use owning_ref::ArcRef;
 use rollsum;
-use sha2;
 use sodiumoxide::crypto::box_;
 use std::{io, mem};
 use std::io::Write;
@@ -167,16 +166,16 @@ impl SGBuf {
 
     /// Calculate digest
     pub fn calculate_digest(&self) -> Vec<u8> {
-        let mut sha = sha2::Sha256::new();
+        let mut sha256 = Sha256::default();
 
         for sg_part in &self.0 {
-            sha.input(sg_part);
+            sha256.input(sg_part);
         }
 
-        let mut sha256 = vec![0u8; DIGEST_SIZE];
-        sha.result(&mut sha256);
+        let mut vec_result = vec![0u8; DIGEST_SIZE];
+        vec_result.copy_from_slice(&sha256.result());
 
-        sha256
+        vec_result
     }
 
     pub fn compress(&self) -> SGBuf {

--- a/lib/src/tests.rs
+++ b/lib/src/tests.rs
@@ -3,8 +3,7 @@ mod lib {
 }
 
 use config::ChunkingAlgorithm;
-use crypto::digest::Digest;
-use crypto::sha2;
+use sha2::{Sha256, Digest};
 use iterators::StoredChunks;
 use rand::{self, Rng};
 use serialize::hex::ToHex;
@@ -49,7 +48,7 @@ struct ExampleDataGen {
     b: Vec<u8>,
     c: Vec<u8>,
     count: usize,
-    sha: sha2::Sha256,
+    sha: Sha256,
 }
 
 impl ExampleDataGen {
@@ -60,14 +59,14 @@ impl ExampleDataGen {
             b: rand_data(1024 * 2),
             c: rand_data(1024 * 2),
             count: kb,
-            sha: sha2::Sha256::new(),
+            sha: Sha256::default(),
         }
     }
 
-    fn finish(&mut self) -> Vec<u8> {
-        let mut digest = vec![0u8; 32];
-        self.sha.result(&mut digest);
-        digest
+    fn finish(self) -> Vec<u8> {
+        let mut vec_result = vec![0u8; DIGEST_SIZE];
+        vec_result.copy_from_slice(&self.sha.result());
+        vec_result
     }
 }
 
@@ -186,10 +185,10 @@ fn random_sanity() {
         let mut data = vec![];
         repo.read(&name, &mut data, &seckey).unwrap();
 
-        let mut sha = sha2::Sha256::new();
+        let mut sha = Sha256::default();
         sha.input(&data);
-        let mut read_digest = vec![0u8; 32];
-        sha.result(&mut read_digest);
+        let mut read_digest = vec![0u8; DIGEST_SIZE];
+        read_digest.copy_from_slice(&sha.result());
         assert_eq!(digest, &read_digest);
     }
 
@@ -198,10 +197,10 @@ fn random_sanity() {
             let mut data = vec![];
             repo.read(&name, &mut data, &seckey).unwrap();
 
-            let mut sha = sha2::Sha256::new();
+            let mut sha = Sha256::default();
             sha.input(&data);
-            let mut read_digest = vec![0u8; 32];
-            sha.result(&mut read_digest);
+            let mut read_digest = vec![0u8; DIGEST_SIZE];
+            read_digest.copy_from_slice(&sha.result());
             assert_eq!(&digest, &read_digest);
         }
 


### PR DESCRIPTION
Issue #94.

I've only did minimal changes. I think it's should be possible to remove `vec![0u8; DIGEST_SIZE]` and use instead stack-allocated arrays (be it `[u8; 32]` or `GenericArray`).