### PR TITLE
Removed the need for a custom rust-hex crate

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -31,7 +31,7 @@ num_cpus = "1.2.1"
 crossbeam = "0.2.10"
 slog = "2"
 slog-perf = "0.1"
-hex = { git = "https://github.com/dpc/rust-hex" }
+hex = "0.2"
 
 [dev-dependencies]
 rand = "0.3.14"

--- a/lib/src/iterators.rs
+++ b/lib/src/iterators.rs
@@ -56,8 +56,12 @@ impl Iterator for StoredChunks {
             }
             // We have landed on a file, we need to verify the file is a valid
             // chunk by parsing the hex code in the file name.
-            let name = entry.file_name().to_string_lossy().to_string();
-            match name.from_hex() {
+            let name = entry
+                .file_name()
+                .to_string_lossy()
+                .to_string()
+                .into_bytes();
+            match Vec::from_hex(name) {
                 Ok(digest) => {
                     if digest.len() == self.digest_size {
                         return Some(Ok(digest));

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -133,11 +133,12 @@ fn chunk_path_by_digest(repo_dir: &Path,
         DataType::Index => Path::new(config::INDEX_SUBDIR),
     };
 
+    let hex_digest = &digest.to_hex();
     repo_dir
         .join(i_or_c)
-        .join(&digest[0..1].to_hex())
-        .join(digest[1..2].to_hex())
-        .join(&digest.to_hex())
+        .join(&hex_digest[0..2])
+        .join(&hex_digest[2..4])
+        .join(&hex_digest)
 }
 
 /// Writer that counts how many bytes were written to it


### PR DESCRIPTION
We need to do this so we can publish a new version.