### PR TITLE
replace rustc_serialize with rust-hex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,10 +363,10 @@ name = "rdedup"
 version = "3.0.0-0.0.1"
 dependencies = [
  "clap 2.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdedup-lib 3.0.0-0.0.1",
  "rpassword 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-async 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-term 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -432,11 +432,6 @@ dependencies = [
  "libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "same-file"
@@ -778,7 +773,6 @@ dependencies = [
 "checksum redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "8dde11f18c108289bef24469638a04dce49da56084f2d50618b226e47eb04509"
 "checksum rpassword 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "320da1dfcf5c570a6c07ff60bb7cd4cdc986d2ea89caea139f2247371ab6a1df"
 "checksum rust-lzma 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6765d37542f590bad98db0514eda612995a71100d91ac3929710bf93b5ba90a5"
-"checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum same-file 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d931a44fdaa43b8637009e7632a02adc4f2b2e0733c08caa4cf00e8da4a117a7"
 "checksum serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)" = "34b623917345a631dc9608d5194cc206b3fe6c3554cd1c75b937e55e285254af"
 "checksum serde_codegen_internals 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bc888bd283bd2420b16ad0d860e35ad8acb21941180a83a189bb2046f9d00400"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ debug-assertions = false
 [dependencies]
 rdedup-lib = { version = "3.0.0-0.0.1", path = "lib" }
 log = "0.3.6"
-rustc-serialize = "0.3.19"
+hex = "0.2"
 clap = "2"
 rpassword = "0.2.3"
 slog = { version = "2.0.10", features = ["max_level_trace", "release_max_level_trace"]}

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -116,7 +116,7 @@
 extern crate clap;
 extern crate rdedup_lib as lib;
 extern crate rpassword;
-extern crate rustc_serialize as serialize;
+extern crate hex;
 #[macro_use]
 extern crate slog;
 extern crate slog_async;
@@ -125,7 +125,7 @@ extern crate slog_term;
 
 use lib::Repo;
 use lib::settings;
-use serialize::hex::ToHex;
+use hex::ToHex;
 use slog::Drain;
 use std::{env, io, process};
 


### PR DESCRIPTION
rustc_serialize is deprecated, hex is already used in lib