### PR TITLE
Fix extensions in store names getting clobbered

### DIFF
--- a/lib/src/name.rs
+++ b/lib/src/name.rs
@@ -81,8 +81,7 @@ impl Name {
     pub(crate) fn path(name: &str, gen: Generation) -> PathBuf {
         let mut path: PathBuf = gen.to_string().into();
         path.push(NAME_SUBDIR);
-        path.push(name);
-        path.set_extension("yml");
+        path.push(name.to_string() + ".yml");
         path
     }
 


### PR DESCRIPTION
This allows store names like `foo.bar` to be accurately preserved.