### PR TITLE
travis: use  cargo build --frozen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ default: $(DEFAULT_TARGET)
 ALL_TARGETS += build $(EXAMPLES) test doc
 ifneq ($(RELEASE),)
 $(info RELEASE BUILD: $(PKG_NAME))
-CARGO_FLAGS += --release
+CARGO_FLAGS += --release --frozen
 ALL_TARGETS += bench
 else
 $(info DEBUG BUILD: $(PKG_NAME); use `RELEASE=true make [args]` for release build)


### PR DESCRIPTION
So we can assert that the Cargo.lock file is up-to-date