### PR TITLE
WIP: Fix deprecations and some general improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 cache: cargo
 rust:
   - stable
-  - 1.27.0
+  - 1.39.0
   - beta
   - nightly
 
@@ -24,7 +24,6 @@ env:
     - RUST_BACKTRACE=1
     - RUST_TEST_THREADS=1
   matrix:
-    -
     - RELEASE=true
 
 install:
@@ -39,4 +38,4 @@ notifications:
   webhooks:
     on_success: change  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
-    on_start: false     # default: false
+    on_start: never     # options: [always|never|change] default: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ env:
     - RUST_BACKTRACE=1
     - RUST_TEST_THREADS=1
   matrix:
+    -
     - RELEASE=true
 
 install:

--- a/README.tpl
+++ b/README.tpl
@@ -1,6 +1,6 @@
 <!-- README.md is auto-generated from README.tpl with `cargo readme` -->
 
-<p align="center">
+<p style="text-align:center;">
   <a href="https://travis-ci.org/dpc/{{crate}}">
       <img src="https://img.shields.io/travis/dpc/{{crate}}/master.svg?style=flat-square" alt="Travis CI Build Status">
   </a>

--- a/lib/src/aio/b2.rs
+++ b/lib/src/aio/b2.rs
@@ -141,18 +141,18 @@ impl B2Thread {
 }
 
 impl Backend for B2 {
-    fn new_thread(&self) -> io::Result<Box<BackendThread>> {
+    fn new_thread(&self) -> io::Result<Box<dyn BackendThread>> {
         Ok(Box::new(B2Thread::new_from_cred(
             &self.cred,
             self.bucket.clone(),
         )?))
     }
 
-    fn lock_exclusive(&self) -> io::Result<Box<aio::Lock>> {
+    fn lock_exclusive(&self) -> io::Result<Box<dyn aio::Lock>> {
         Ok(Box::new(Lock::new(PathBuf::from(config::LOCK_FILE))))
     }
 
-    fn lock_shared(&self) -> io::Result<Box<aio::Lock>> {
+    fn lock_shared(&self) -> io::Result<Box<dyn aio::Lock>> {
         Ok(Box::new(Lock::new(PathBuf::from(config::LOCK_FILE))))
     }
 }

--- a/lib/src/aio/backend.rs
+++ b/lib/src/aio/backend.rs
@@ -17,15 +17,15 @@ pub(crate) trait Backend: Send + Sync {
     ///
     /// Use to protect operations that are potentially destructive,
     /// like GC.
-    fn lock_exclusive(&self) -> io::Result<Box<Lock>>;
+    fn lock_exclusive(&self) -> io::Result<Box<dyn Lock>>;
     /// Lock the repository in shared mode
     ///
     /// This will only prevent anyone from grabing exclusive lock.
     /// Use to protect operations that only add new data, like `write`.
-    fn lock_shared(&self) -> io::Result<Box<Lock>>;
+    fn lock_shared(&self) -> io::Result<Box<dyn Lock>>;
 
     /// Spawn a new thread object of the backend.
-    fn new_thread(&self) -> io::Result<Box<BackendThread>>;
+    fn new_thread(&self) -> io::Result<Box<dyn BackendThread>>;
 }
 
 pub(crate) trait BackendThread: Send {

--- a/lib/src/aio/local.rs
+++ b/lib/src/aio/local.rs
@@ -35,7 +35,7 @@ struct LocalThread {
 }
 
 impl Backend for Local {
-    fn new_thread(&self) -> io::Result<Box<BackendThread>> {
+    fn new_thread(&self) -> io::Result<Box<dyn BackendThread>> {
         Ok(Box::new(LocalThread {
             path: self.path.clone(),
             rand_ext: rand::thread_rng()
@@ -45,7 +45,7 @@ impl Backend for Local {
         }))
     }
 
-    fn lock_exclusive(&self) -> io::Result<Box<Lock>> {
+    fn lock_exclusive(&self) -> io::Result<Box<dyn Lock>> {
         let lock_path = lock_file_path(&self.path);
 
         let file = fs::File::create(&lock_path)?;
@@ -54,7 +54,7 @@ impl Backend for Local {
         Ok(Box::new(file))
     }
 
-    fn lock_shared(&self) -> io::Result<Box<Lock>> {
+    fn lock_shared(&self) -> io::Result<Box<dyn Lock>> {
         let lock_path = lock_file_path(&self.path);
 
         let file = fs::File::create(&lock_path)?;

--- a/lib/src/aio/local.rs
+++ b/lib/src/aio/local.rs
@@ -35,16 +35,6 @@ struct LocalThread {
 }
 
 impl Backend for Local {
-    fn new_thread(&self) -> io::Result<Box<dyn BackendThread>> {
-        Ok(Box::new(LocalThread {
-            path: self.path.clone(),
-            rand_ext: rand::thread_rng()
-                .sample_iter(&Alphanumeric)
-                .take(20)
-                .collect::<String>(),
-        }))
-    }
-
     fn lock_exclusive(&self) -> io::Result<Box<dyn Lock>> {
         let lock_path = lock_file_path(&self.path);
 
@@ -62,15 +52,30 @@ impl Backend for Local {
 
         Ok(Box::new(file))
     }
+
+    fn new_thread(&self) -> io::Result<Box<dyn BackendThread>> {
+        Ok(Box::new(LocalThread {
+            path: self.path.clone(),
+            rand_ext: rand::thread_rng()
+                .sample_iter(&Alphanumeric)
+                .take(20)
+                .collect::<String>(),
+        }))
+    }
 }
 
 impl Local {
     pub(crate) fn new(path: PathBuf) -> Self {
-        Local { path: path }
+        Local { path }
     }
 }
 
 impl BackendThread for LocalThread {
+    fn remove_dir_all(&mut self, path: PathBuf) -> io::Result<()> {
+        let path = self.path.join(path);
+        fs::remove_dir_all(&path)
+    }
+
     fn rename(
         &mut self,
         src_path: PathBuf,
@@ -86,11 +91,6 @@ impl BackendThread for LocalThread {
                 fs::rename(&src_path, &dst_path)
             }
         }
-    }
-
-    fn remove_dir_all(&mut self, path: PathBuf) -> io::Result<()> {
-        let path = self.path.join(path);
-        fs::remove_dir_all(&path)
     }
 
     fn write(

--- a/lib/src/aio/mod.rs
+++ b/lib/src/aio/mod.rs
@@ -125,10 +125,10 @@ impl AsyncIO {
         }
 
         let shared = AsyncIOShared {
-            join: join,
+            join,
             log: log.clone(),
             stats: shared.clone(),
-            backend: backend,
+            backend,
         };
 
         Ok(AsyncIO {
@@ -152,7 +152,7 @@ impl AsyncIO {
     pub fn list(&self, path: PathBuf) -> AsyncIOResult<Vec<PathBuf>> {
         let (tx, rx) = mpsc::channel();
         self.tx.send(Message::List(path, tx));
-        AsyncIOResult { rx: rx }
+        AsyncIOResult { rx }
     }
 
     // TODO: No need for it anymore?
@@ -176,12 +176,12 @@ impl AsyncIO {
     pub fn write(&self, path: PathBuf, sg: SGData) -> AsyncIOResult<()> {
         let (tx, rx) = mpsc::channel();
         self.tx.send(Message::Write(WriteArgs {
-            path: path,
+            path,
             data: sg,
             idempotent: false,
             complete_tx: Some(tx),
         }));
-        AsyncIOResult { rx: rx }
+        AsyncIOResult { rx }
     }
 
     // TODO: No need for it anymore
@@ -193,12 +193,12 @@ impl AsyncIO {
     ) -> AsyncIOResult<()> {
         let (tx, rx) = mpsc::channel();
         self.tx.send(Message::Write(WriteArgs {
-            path: path,
+            path,
             data: sg,
             idempotent: true,
             complete_tx: Some(tx),
         }));
-        AsyncIOResult { rx: rx }
+        AsyncIOResult { rx }
     }
 
     /// Will panic the worker thread if fails, but does not require
@@ -207,7 +207,7 @@ impl AsyncIO {
     #[allow(dead_code)]
     pub fn write_checked(&self, path: PathBuf, sg: SGData) {
         self.tx.send(Message::Write(WriteArgs {
-            path: path,
+            path,
             data: sg,
             idempotent: false,
             complete_tx: None,
@@ -216,7 +216,7 @@ impl AsyncIO {
 
     pub fn write_checked_idempotent(&self, path: PathBuf, sg: SGData) {
         self.tx.send(Message::Write(WriteArgs {
-            path: path,
+            path,
             data: sg,
             idempotent: true,
             complete_tx: None,
@@ -226,7 +226,7 @@ impl AsyncIO {
     pub fn read(&self, path: PathBuf) -> AsyncIOResult<SGData> {
         let (tx, rx) = mpsc::channel();
         self.tx.send(Message::Read(path, tx));
-        AsyncIOResult { rx: rx }
+        AsyncIOResult { rx }
     }
 
     pub(crate) fn read_metadata(
@@ -235,25 +235,25 @@ impl AsyncIO {
     ) -> AsyncIOResult<Metadata> {
         let (tx, rx) = mpsc::channel();
         self.tx.send(Message::ReadMetadata(path, tx));
-        AsyncIOResult { rx: rx }
+        AsyncIOResult { rx }
     }
 
     pub fn remove(&self, path: PathBuf) -> AsyncIOResult<()> {
         let (tx, rx) = mpsc::channel();
         self.tx.send(Message::Remove(path, tx));
-        AsyncIOResult { rx: rx }
+        AsyncIOResult { rx }
     }
 
     pub fn remove_dir_all(&self, path: PathBuf) -> AsyncIOResult<()> {
         let (tx, rx) = mpsc::channel();
         self.tx.send(Message::RemoveDirAll(path, tx));
-        AsyncIOResult { rx: rx }
+        AsyncIOResult { rx }
     }
 
     pub fn rename(&self, src: PathBuf, dst: PathBuf) -> AsyncIOResult<()> {
         let (tx, rx) = mpsc::channel();
         self.tx.send(Message::Rename(src, dst, tx));
-        AsyncIOResult { rx: rx }
+        AsyncIOResult { rx }
     }
 }
 
@@ -362,8 +362,8 @@ impl AsyncIOThread {
         );
         AsyncIOThread {
             log: log.new(o!("module" => "asyncio")),
-            shared: shared,
-            rx: rx,
+            shared,
+            rx,
             time_reporter: t,
             backend: RefCell::new(backend),
         }

--- a/lib/src/chunk_processor.rs
+++ b/lib/src/chunk_processor.rs
@@ -41,13 +41,13 @@ impl ChunkProcessor {
         assert!(generations.len() >= 1);
         ChunkProcessor {
             log: repo.log.clone(),
-            repo: repo,
-            rx: rx,
-            aio: aio,
-            encrypter: encrypter,
-            compressor: compressor,
-            hasher: hasher,
-            generations: generations,
+            repo,
+            rx,
+            aio,
+            encrypter,
+            compressor,
+            hasher,
+            generations,
         }
     }
 

--- a/lib/src/chunking.rs
+++ b/lib/src/chunking.rs
@@ -83,17 +83,17 @@ pub(crate) struct Chunker<I> {
     pending: Option<ArcRef<Vec<u8>, [u8]>>,
 
     chunks_returned: usize,
-    chunking: Box<Chunking>,
+    chunking: Box<dyn Chunking>,
 }
 
 impl<I> Chunker<I> {
-    pub fn new(iter: I, chunking: Box<Chunking>) -> Self {
+    pub fn new(iter: I, chunking: Box<dyn Chunking>) -> Self {
         Chunker {
-            iter: iter,
+            iter,
             incomplete_chunk: SGData::empty(),
             pending: None,
             chunks_returned: 0,
-            chunking: chunking,
+            chunking,
         }
     }
 }

--- a/lib/src/compression.rs
+++ b/lib/src/compression.rs
@@ -27,7 +27,7 @@ use lzma;
 #[cfg(feature = "with-zstd")]
 use zstd;
 
-pub type ArcCompression = Arc<Compression + Send + Sync>;
+pub type ArcCompression = Arc<dyn Compression + Send + Sync>;
 
 pub trait Compression {
     fn compress(&self, buf: SGData) -> io::Result<SGData>;

--- a/lib/src/compression.rs
+++ b/lib/src/compression.rs
@@ -60,7 +60,7 @@ impl Deflate {
             flate2::Compression::default()
         };
 
-        Deflate { level: level }
+        Deflate { level }
     }
 }
 #[cfg(feature = "with-deflate")]
@@ -104,7 +104,7 @@ impl Bzip2 {
             bzip2::Compression::Default
         };
 
-        Bzip2 { level: level }
+        Bzip2 { level }
     }
 }
 #[cfg(feature = "with-bzip2")]
@@ -142,7 +142,7 @@ impl Xz2 {
     pub fn new(level: i32) -> Self {
         let level = cmp::min(cmp::max(level + 6, 0), 10) as u32;
 
-        Xz2 { level: level }
+        Xz2 { level }
     }
 }
 #[cfg(feature = "with-xz2")]
@@ -198,7 +198,7 @@ pub struct Zstd {
 #[cfg(feature = "with-zstd")]
 impl Zstd {
     pub fn new(level: i32) -> Self {
-        Zstd { level: level }
+        Zstd { level }
     }
 }
 

--- a/lib/src/config/chunking.rs
+++ b/lib/src/config/chunking.rs
@@ -39,7 +39,7 @@ impl Chunking {
         }
     }
 
-    pub(crate) fn to_engine(&self) -> Box<chunking::Chunking> {
+    pub(crate) fn to_engine(&self) -> Box<dyn chunking::Chunking> {
         match *self {
             Chunking::Bup { chunk_bits } => {
                 Box::new(chunking::Bup::new(chunk_bits))

--- a/lib/src/config/compression.rs
+++ b/lib/src/config/compression.rs
@@ -55,7 +55,7 @@ pub struct Deflate {
 #[cfg(feature = "with-deflate")]
 impl Deflate {
     pub fn new(level: i32) -> Self {
-        Deflate { level: level }
+        Deflate { level }
     }
 }
 #[cfg(feature = "with-bzip2")]
@@ -67,7 +67,7 @@ pub struct Bzip2 {
 #[cfg(feature = "with-bzip2")]
 impl Bzip2 {
     pub fn new(level: i32) -> Self {
-        Bzip2 { level: level }
+        Bzip2 { level }
     }
 }
 
@@ -80,7 +80,7 @@ pub struct Zstd {
 #[cfg(feature = "with-zstd")]
 impl Zstd {
     pub fn new(level: i32) -> Self {
-        Zstd { level: level }
+        Zstd { level }
     }
 }
 
@@ -93,6 +93,6 @@ pub struct Xz2 {
 #[cfg(feature = "with-xz2")]
 impl Xz2 {
     pub fn new(level: i32) -> Self {
-        Xz2 { level: level }
+        Xz2 { level }
     }
 }

--- a/lib/src/config/mod.rs
+++ b/lib/src/config/mod.rs
@@ -167,9 +167,9 @@ impl Repo {
 
         Ok(Repo {
             version: REPO_VERSION_CURRENT,
-            pwhash: pwhash,
+            pwhash,
             chunking: settings.chunking.0,
-            encryption: encryption,
+            encryption,
             compression: settings
                 .compression
                 .to_config(settings.compression_level),

--- a/lib/src/encryption.rs
+++ b/lib/src/encryption.rs
@@ -9,8 +9,8 @@ use config;
 use std::io;
 use std::sync::Arc;
 
-pub type ArcEncrypter = Arc<Encrypter + Send + Sync>;
-pub type ArcDecrypter = Arc<Decrypter + Send + Sync>;
+pub type ArcEncrypter = Arc<dyn Encrypter + Send + Sync>;
+pub type ArcDecrypter = Arc<dyn Decrypter + Send + Sync>;
 
 pub(crate) trait EncryptionEngine {
     fn change_passphrase(
@@ -80,7 +80,7 @@ pub struct Curve25519 {
 impl Curve25519 {
     pub(crate) fn new(
         passphrase_f: PassphraseFn,
-        pwhash: &pwhash::PWHash,
+        pwhash: &dyn pwhash::PWHash,
     ) -> super::Result<Self> {
         let (pk, sk) = box_::gen_keypair();
         let passphrase = passphrase_f()?;
@@ -104,7 +104,7 @@ impl Curve25519 {
 
     fn unseal_decrypt(
         &self,
-        passphrase_f: &Fn() -> io::Result<String>,
+        passphrase_f: &dyn Fn() -> io::Result<String>,
         pwhash: &config::PWHash,
     ) -> io::Result<box_::SecretKey> {
         let passphrase = passphrase_f()?;
@@ -167,7 +167,7 @@ impl EncryptionEngine for Curve25519 {
     }
     fn decrypter(
         &self,
-        pass: &Fn() -> io::Result<String>,
+        pass: &dyn Fn() -> io::Result<String>,
         pwhash: &config::PWHash,
     ) -> io::Result<ArcDecrypter> {
         let key = self.unseal_decrypt(pass, pwhash)?;

--- a/lib/src/encryption.rs
+++ b/lib/src/encryption.rs
@@ -98,7 +98,7 @@ impl Curve25519 {
         Ok(Curve25519 {
             sealed_sec_key: sealed_sk,
             pub_key: pk,
-            nonce: nonce,
+            nonce,
         })
     }
 

--- a/lib/src/generation.rs
+++ b/lib/src/generation.rs
@@ -107,8 +107,8 @@ impl Generation {
         };
 
         Ok(Generation {
-            seq: seq,
-            rand: rand,
+            seq,
+            rand,
         })
     }
 

--- a/lib/src/generation.rs
+++ b/lib/src/generation.rs
@@ -180,10 +180,8 @@ fn generation_from_str() {
         Generation::try_from("0123456701234567-1234123412341234").unwrap();
     println!("{:x}", gen.seq);
     println!("{:x}", gen.rand);
-    assert!(
-        gen == Generation {
-            seq: 0x0123456701234567,
-            rand: 0x1234123412341234,
-        }
-    )
+    assert_eq!(gen, Generation {
+        seq: 0x0123456701234567,
+        rand: 0x1234123412341234,
+    })
 }

--- a/lib/src/hashing.rs
+++ b/lib/src/hashing.rs
@@ -6,7 +6,7 @@ use digest::{FixedOutput, Input};
 use sha2;
 use std::sync::Arc;
 
-pub type ArcHasher = Arc<Hasher + Send + Sync>;
+pub type ArcHasher = Arc<dyn Hasher + Send + Sync>;
 
 pub trait Hasher {
     fn calculate_digest(&self, sg: &SGData) -> Vec<u8>;

--- a/lib/src/iterators.rs
+++ b/lib/src/iterators.rs
@@ -28,9 +28,9 @@ impl StoredChunks {
         let paths = aio.list_recursively(rel_path);
 
         Ok(StoredChunks {
-            paths: paths,
-            digest_size: digest_size,
-            log: log,
+            paths,
+            digest_size,
+            log,
         })
     }
 }

--- a/lib/src/iterators.rs
+++ b/lib/src/iterators.rs
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 /// digest sized elements as their name.  Invalid files with incorrect names
 /// will be ignored.
 pub struct StoredChunks {
-    paths: Box<Iterator<Item = io::Result<PathBuf>>>,
+    paths: Box<dyn Iterator<Item = io::Result<PathBuf>>>,
     digest_size: usize,
     log: Logger,
 }

--- a/lib/src/sorting_recv.rs
+++ b/lib/src/sorting_recv.rs
@@ -21,7 +21,7 @@ pub struct SortingIterator<T, I> {
 impl<T, I> SortingIterator<T, I> {
     pub fn new(iter: I) -> Self {
         SortingIterator {
-            iter: iter,
+            iter,
             early_items: Default::default(),
             next_i: 0,
         }

--- a/lib/src/tests.rs
+++ b/lib/src/tests.rs
@@ -107,7 +107,7 @@ impl io::Read for ExampleDataGen {
         }
         self.count -= 1;
 
-        let len = match rand::weak_rng().gen_range(0, 3) {
+        let len = match rand::thread_rng().gen_range(0, 3) {
             0 => copy_as_much_as_possible(buf, &self.a),
             1 => copy_as_much_as_possible(buf, &self.b),
             2 => copy_as_much_as_possible(buf, &self.c),
@@ -121,7 +121,7 @@ impl io::Read for ExampleDataGen {
 }
 
 fn rand_data(len: usize) -> Vec<u8> {
-    rand::weak_rng().gen_iter().take(len).collect::<Vec<u8>>()
+    rand::thread_rng().gen_iter().take(len).collect::<Vec<u8>>()
 }
 
 fn wipe(repo: &lib::Repo) {
@@ -194,7 +194,7 @@ fn random_sanity() {
 
     for i in 0..10 {
         let mut data =
-            ExampleDataGen::new(rand::weak_rng().gen_range(0, 10 * 1024));
+            ExampleDataGen::new(rand::thread_rng().gen_range(0, 10 * 1024));
         let name = format!("{:x}", i);
         repo.write(&name, &mut data, &enc_handle).unwrap();
         names.push((name, data.finish()));

--- a/lib/src/util/mod.rs
+++ b/lib/src/util/mod.rs
@@ -97,16 +97,16 @@ where
     }
 
     #[inline]
+    fn count(self) -> usize {
+        self.iter.count()
+    }
+
+    #[inline]
     fn nth(&mut self, n: usize) -> Option<(u64, I::Item)> {
         self.iter.nth(n).map(|a| {
             let i = self.count + n as u64;
             self.count = i + 1;
             (i, a)
         })
-    }
-
-    #[inline]
-    fn count(self) -> usize {
-        self.iter.count()
     }
 }

--- a/lib/src/util/readerveciter.rs
+++ b/lib/src/util/readerveciter.rs
@@ -15,8 +15,8 @@ where
 {
     pub fn new(reader: R, buf_size: usize) -> Self {
         ReaderVecIter {
-            reader: reader,
-            buf_size: buf_size,
+            reader,
+            buf_size,
         }
     }
 }

--- a/lib/src/util/serde.rs
+++ b/lib/src/util/serde.rs
@@ -8,7 +8,7 @@ use {base64, box_, secretbox, serde};
 
 pub trait MyTryFromBytes: Sized {
     type Err: 'static + Sized + ::std::error::Error;
-    fn try_from(&[u8]) -> Result<Self, Self::Err>;
+    fn try_from(_: &[u8]) -> Result<Self, Self::Err>;
 }
 
 impl MyTryFromBytes for box_::PublicKey {
@@ -67,7 +67,7 @@ where
         })
         .and_then(|ref bytes| {
             T::try_from(bytes).map_err(|err| {
-                Error::custom(format!("{}", &err as &::std::error::Error))
+                Error::custom(format!("{}", &err as &dyn(::std::error::Error)))
             })
         })
 }
@@ -93,7 +93,7 @@ where
         })
         .and_then(|bytes: Vec<u8>| {
             T::try_from(&bytes).map_err(|err| {
-                Error::custom(format!("{}", &err as &::std::error::Error))
+                Error::custom(format!("{}", &err as &dyn(::std::error::Error)))
             })
         })
 }

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -159,7 +159,7 @@ struct Options {
 impl Options {
     fn new(url: Url) -> Options {
         Options {
-            url: url,
+            url,
             debug_level: 0,
             settings: settings::Repo::new(),
         }
@@ -496,7 +496,7 @@ fn run() -> io::Result<()> {
         ("list", Some(_matches)) => {
             let repo = Repo::open(&options.url, log)?;
 
-            for name in try!(repo.list_names()) {
+            for name in repo.list_names()? {
                 println!("{}", name);
             }
         }

--- a/tester/src/bin.rs
+++ b/tester/src/bin.rs
@@ -48,7 +48,7 @@ impl ExampleDataGen {
 }
 
 fn rand_data(len: usize) -> Vec<u8> {
-    rand::weak_rng().gen_iter().take(len).collect::<Vec<u8>>()
+    (0..len).map(|_| { rand::random::<u8>() }).collect::<Vec<u8>>()
 }
 
 fn simple_digest(data: &[u8]) -> Vec<u8> {
@@ -138,9 +138,9 @@ impl TestState {
     }
 
     fn select_random_name(&self) -> NameStats {
-        let random_name =
-            rand::sample(&mut thread_rng(), self.names.keys(), 1)[0];
-
+        let mut rng = thread_rng();
+        let random_key = rng.gen_range(0, self.names.keys().len());
+        let random_name = self.names.keys().nth(random_key).unwrap();
         self.names.get(random_name).unwrap().clone()
     }
 


### PR DESCRIPTION
Thanks for this awesome project, I'm impressed. Would love to see more community activity here... Tried to improve some minor things reported by `cargo check` and *IntelliJ* in this pull request. Since I'm pretty new to rust, i hope i did not break anything....

This project is nearly exactly what i was looking for. One thing i would like to implement is a recursive file iterator to enable standalone usage (no `rdup` required) considering https://github.com/sharkdp/fd as a start. I have to find out how `rdup` and `rdup-up` exactly work, but what do you think about a wrapper around `&mut io::stdin()` to provide a reader that merges/redirects a possible input argument iterator AND all `stdin`? Like:

```
# still works
rdup -x /dev/null "$HOME" | rdedup store home
rdedup load home | rdup-up "$HOME.restored"

# also works without rdup
rdedup store home "$HOME"
rdedup load home "$HOME.restored"
```

Before doing so i have to read some more code and further rust docs first - this multithreading code is far from being easy to understand - but maybe i do not need to even touch many parts of the code to get the above working.


