### PR TITLE
Fix and simplify CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,23 @@ rust:
   - beta
   - nightly
 
-before_install:
+install:
   - sudo apt-get install -y liblzma-dev
   - sudo apt-get install -y libbz2-dev
+# disabled until fmt stabilized: cargo install -f rustfmt
+# - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo install -f clippy; fi
+
+# NOTE: travis executes all script steps even if one fails, so we keep it in a single step to fail fast
 script:
-  - export PATH=$PATH:~/.cargo/bin
-# - disabled until fmt stabilized: ./scripts/check-fmt.sh
-# - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo clippy && cd lib && cargo clippy; cd ..; fi
-  - make all
-  - make travistest
-  - if [ ! -z "$RELEASE" ] ; then cd tester; cargo build --release; cd ..; rm -Rf /tmp/rdedup-tester/; ./target/release/tester 200; fi
-  - if [ ! -z "$RELEASE" ] ; then ./scripts/e2e-test.sh; fi
-  - if [ ! -z "$RELEASE" ] ; then cd lib && make travistest; fi
+  - |
+    set -o errexit
+    # disabled until fmt stabilized: ./scripts/check-fmt.sh
+    #if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo clippy && cd lib && cargo clippy; cd ..; fi
+    make all
+    make travistest
+    if [ ! -z "$RELEASE" ] ; then cd tester; cargo build --release; cd ..; rm -Rf /tmp/rdedup-tester/; ./target/release/tester 200; fi
+    if [ ! -z "$RELEASE" ] ; then ./scripts/e2e-test.sh; fi
+    if [ ! -z "$RELEASE" ] ; then cd lib && make travistest; fi
 
 env:
   global:
@@ -26,11 +31,6 @@ env:
   matrix:
     -
     - RELEASE=true
-
-install:
-# - disabled until fmt stabilized: cargo install -f rustfmt
-# - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo install -f clippy; fi
-  - ls -ahl ~/.cargo/bin/
 
 notifications:
   webhooks:

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ default: $(DEFAULT_TARGET)
 ALL_TARGETS += build $(EXAMPLES) test doc
 ifneq ($(RELEASE),)
 $(info RELEASE BUILD: $(PKG_NAME))
-CARGO_FLAGS += --release --frozen
+CARGO_FLAGS += --release --locked
 ALL_TARGETS += bench
 else
 $(info DEBUG BUILD: $(PKG_NAME); use `RELEASE=true make [args]` for release build)


### PR DESCRIPTION
 - The build was broken because of the use of `--frozen` - this doesn't permit downloading anything at all. Instead I've migrated to use `--locked`, which instead ensures that the lockfile is already up to date
 - Per https://docs.travis-ci.com/user/job-lifecycle#breaking-the-build, a failure in `script` will not cause an immediate failure. This is undesirable (if you can't do the initial build, there's no point doing tests and it can cause confusing error messages) so I've consolidated it all into one
 - As part of this, I'm 80% sure that each `script` step is run in a separate shell, so `export` was redundant and not doing anything - I've eliminated it
 - I've consolidated `before_install` and `install` together, and removed a seemingly redundant step

CI now passes, which it didn't before :smile:  - you can see my successful build at https://travis-ci.org/aidanhs/rdedup/builds/631141736