### PR TITLE
Convert to `structopt`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -330,7 +330,7 @@ dependencies = [
  "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -359,7 +359,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -492,6 +492,14 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "hex"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,7 +575,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -679,7 +687,7 @@ name = "native-tls"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -730,7 +738,7 @@ dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.9.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -771,6 +779,30 @@ version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro-error-attr 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn-mid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,11 +811,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "quote"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.28 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -910,7 +958,7 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -919,7 +967,6 @@ dependencies = [
 name = "rdedup"
 version = "3.1.1"
 dependencies = [
- "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdedup-lib 3.1.0",
@@ -927,6 +974,7 @@ dependencies = [
  "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-async 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-term 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1072,7 +1120,7 @@ name = "schannel"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1240,6 +1288,28 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "structopt"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt-derive 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-error 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "syn"
 version = "0.15.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1247,6 +1317,26 @@ dependencies = [
  "proc-macro2 0.4.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn-mid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1333,7 +1423,7 @@ name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1386,6 +1476,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1393,6 +1488,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "unicode-xid"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1418,6 +1518,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "version_check"
 version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "version_check"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1561,6 +1666,7 @@ dependencies = [
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+"checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6a22814455d41612f41161581c2883c0c6a1c41852729b17d5ed88f01e153aa"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
@@ -1570,7 +1676,7 @@ dependencies = [
 "checksum isatty 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e31a8281fc93ec9693494da65fbf28c0c2aa60a2eaec25dc58e2f31952e95edc"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
-"checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
+"checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "bedcc7a809076656486ffe045abeeac163da1b558e963a31e29fbfbeba916917"
 "checksum libflate 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)" = "d9135df43b1f5d0e333385cb6e7897ecd1a43d7d11b91ac003f4d2c2d2401fdd"
 "checksum libsodium-sys 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1c344ff12b90ef8fa1f0fffacd348c1fd041db331841fec9eab23fdb991f5e73"
@@ -1596,8 +1702,12 @@ dependencies = [
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
+"checksum proc-macro-error 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fc175e9777c3116627248584e8f8b3e2987405cabe1c0adf7d1dd28f09dc7880"
+"checksum proc-macro-error-attr 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3cc9795ca17eb581285ec44936da7fc2335a3f34f2ddd13118b6f4d515435c50"
 "checksum proc-macro2 0.4.28 (registry+https://github.com/rust-lang/crates.io-index)" = "ba92c84f814b3f9a44c5cfca7d2ad77fa10710867d2bbb1b3d175ab5f47daa12"
+"checksum proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
 "checksum quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faf4799c5d274f3868a4aae320a0a182cbd2baee377b378f080e16a23e9d80db"
+"checksum quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 "checksum rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 "checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
@@ -1646,7 +1756,11 @@ dependencies = [
 "checksum sodiumoxide 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585232e78a4fc18133eef9946d3080befdf68b906c51b621531c37e91787fa2b"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+"checksum structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "de2f5e239ee807089b62adce73e48c625e0ed80df02c7ab3f068f5db5281065c"
+"checksum structopt-derive 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "510413f9de616762a4fbeab62509bf15c729603b72d7cd71280fbca431b1c118"
 "checksum syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)" = "ec52cd796e5f01d0067225a5392e70084acc4c0013fa71d55166d38a8b307836"
+"checksum syn 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)" = "4cdb98bcb1f9d81d07b536179c269ea15999b5d14ea958196413869445bb5250"
+"checksum syn-mid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 "checksum tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)" = "b3196bfbffbba3e57481b6ea32249fbaf590396a52505a2615adbb79d9d826d3"
@@ -1662,12 +1776,15 @@ dependencies = [
 "checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
+"checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 "checksum walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1"
 "checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,9 +48,9 @@ members = [ "tester" ]
 rdedup-lib = { version = "3.1.0", path = "lib", default-features = false }
 log = "0.3.6"
 hex = "0.3"
-clap = "2"
 rpassword = "4.0"
 slog = { version = "2.0.10", features = ["max_level_trace", "release_max_level_trace"]}
 slog-term = "2"
 slog-async = "2"
 url = "1"
+structopt = "0.3.15"

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -132,7 +132,6 @@ extern crate url;
 use lib::settings;
 use lib::Repo;
 use slog::Drain;
-use std::error::Error;
 use std::{env, io, process};
 use structopt::StructOpt;
 use url::Url;
@@ -144,7 +143,7 @@ fn parse_url(s: &str) -> io::Result<Url> {
     Url::parse(s).map_err(|e| {
         io::Error::new(
             io::ErrorKind::InvalidData,
-            format!("URI parsing error : {}", e.description()),
+            format!("URI parsing error : {}", e.to_string()),
         )
     })
 }

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -119,7 +119,6 @@
 //! [ddar]: https://github.com/basak/ddar/
 //! [ddar-issue]: https://github.com/basak/ddar/issues/10
 
-extern crate clap;
 extern crate hex;
 extern crate rdedup_lib as lib;
 extern crate rpassword;
@@ -127,14 +126,15 @@ extern crate rpassword;
 extern crate slog;
 extern crate slog_async;
 extern crate slog_term;
+extern crate structopt;
 extern crate url;
 
-use clap::{Arg, SubCommand};
 use lib::settings;
 use lib::Repo;
 use slog::Drain;
 use std::error::Error;
 use std::{env, io, process};
+use structopt::StructOpt;
 use url::Url;
 
 use std::str::FromStr;
@@ -319,66 +319,160 @@ fn create_logger(verbosity: u32, timing_verbosity: u32) -> slog::Logger {
     }
 }
 
-fn run() -> io::Result<()> {
-    let matches = clap::App::new("rdedup")
-        .version(env!("CARGO_PKG_VERSION"))
-        .author("Dawid Ciężarkiewicz <dpc@dpc.pw>")
-        .about("Data deduplication toolkit")
-        .arg(Arg::with_name("REPO_DIR").short("d").long("dir").takes_value(true).value_name("PATH")
-             .help("Path to rdedup repository. Override `RDEDUP_DIR` environment variable"))
-        .arg(Arg::with_name("REPO_URI").short("u").long("repo").takes_value(true).value_name("URI").conflicts_with("REPO_DIR")
-             .help("Rdedup repository URI. Overrides the `RDEDUP_URI` environment variable"))
-        .arg(Arg::with_name("VERBOSE").short("v").multiple(true).help("Increase debugging level for general messages"))
-        .arg(Arg::with_name("VERBOSE_TIMINGS").short("t").multiple(true).help("Increase debugging level for timings"))
-        .subcommand(SubCommand::with_name("init").display_order(0)
-                    .about("Create a new repository")
-                    .arg(Arg::with_name("PWHASH").long("pwhash").takes_value(true).value_name("STRENGTH").possible_values(&["strong", "interactive", "weak"])
-                         .default_value("strong").help("Set pwhash strength"))
-                    .arg(Arg::with_name("CHUNKING").long("chunking").takes_value(true).value_name("SCHEME").possible_values(&["bup", "gear", "fastcdc"])
-                         .default_value("fastcdc").help("Set chunking scheme"))
-                    .arg(Arg::with_name("CHUNK_SIZE").long("chunk-size").takes_value(true).value_name("N").validator(validate_chunk_size)
-                         .default_value("128K").help("Set average chunk size"))
-                    .arg(Arg::with_name("ENCRYPTION").long("encryption").takes_value(true).value_name("SCHEME").possible_values(&["curve25519", "none"])
-                         .default_value("curve25519").help("Set encryption scheme"))
-                    .arg(Arg::with_name("COMPRESSION").long("compression").takes_value(true).value_name("SCHEME")
-                         .possible_values(&["deflate", "xz2", "zstd", "bzip2", "none"])
-                         .default_value("zstd").help("Set compression scheme"))
-                    .arg(Arg::with_name("COMPRESSION_LEVEL").long("compression-level").takes_value(true).value_name("N")
-                         .default_value("0").help("Set compression level where negative numbers mean \"faster\" and positive ones \
-                                                   \"smaller\""))
-                    .arg(Arg::with_name("NESTING").long("nesting").takes_value(true).value_name("N").validator(validate_nesting)
-                         .default_value("2").help("Set level of folder nesting"))
-                    .arg(Arg::with_name("HASHING").long("hashing").takes_value(true).value_name("SCHEME").possible_values(&["sha256", "blake2b"])
-                         .default_value("blake2b").help("Set hashing scheme")))
-        .subcommand(SubCommand::with_name("store").about("Store data to repository").display_order(1)
-                    .arg(Arg::with_name("NAME").required(true).help("Name to store to")))
-        .subcommand(SubCommand::with_name("load").about("Load data from repository").display_order(2)
-                    .arg(Arg::with_name("NAME").required(true).help("Name to load from")))
-        .subcommand(SubCommand::with_name("list").visible_alias("ls").about("List names stored in the repository").display_order(3))
-        .subcommand(SubCommand::with_name("remove").visible_alias("rm").about("Remove name(s) stored in the repository").display_order(4)
-                    .arg(Arg::with_name("NAME").required(true).multiple(true).help("Names to remove")))
-        .subcommand(SubCommand::with_name("change_passphrase").visible_alias("chpasswd")
-                    .about("Change the passphrase protecting the encryption key (if any)"))
-        .subcommand(SubCommand::with_name("gc").about("Garbage collect unreferenced chunks")
-                    .arg(Arg::with_name("GRACE_TIME").long("grace").takes_value(true).value_name("SECONDS").default_value("86400")
-                         .help("Set grace time in seconds")))
-        .subcommand(SubCommand::with_name("verify").about("Verify integrity of data stored in the repository")
-                    .arg(Arg::with_name("NAME").required(true).multiple(true).help("Names to verify")))
-        .subcommand(SubCommand::with_name("du").about("Calculate disk usage due to the data stored for a set of names")
-                    .arg(Arg::with_name("NAME").required(true).multiple(true).help("Names to check")))
-        .setting(clap::AppSettings::SubcommandRequiredElseHelp)
-        .get_matches();
+#[derive(Debug, StructOpt)]
+#[structopt(author, about = "Data deduplication toolkit")]
+struct CliOpts {
+    #[structopt(short = "d", long = "dir", name = "REPO_DIR")]
+    /// Path to rdedup repository. Override `RDEDUP_DIR` environment variable
+    repo_dir: Option<std::ffi::OsString>,
 
-    let url: Url = if let Some(loc) = matches.value_of_os("REPO_URI") {
-        let s = loc.to_os_string().into_string().map_err(|_| {
+    #[structopt(short = "u", long = "repo", conflicts_with = "repo_dir")]
+    /// Rdedup repository URI. Override the `RDEDUP_URI` environment variable
+    repo_uri: Option<std::ffi::OsString>,
+
+    #[structopt(short = "v")]
+    /// Increase debugging level for general messages
+    verbose: Vec<bool>,
+
+    #[structopt(short = "t")]
+    /// Increase debugging level for timings
+    verbose_timings: Vec<bool>,
+
+    #[structopt(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, StructOpt)]
+enum Command {
+    #[structopt(display_order = 0)]
+    /// Create a new repository
+    Init {
+        #[structopt(
+            long,
+            possible_values = &["strong", "interactive", "weak"],
+            default_value = "strong"
+        )]
+        /// Set pwhash strength
+        pwhash: String,
+
+        #[structopt(
+            long,
+            possible_values = &["bup", "gear", "fastcdc"],
+            default_value = "fastcdc"
+        )]
+        /// Set chunking scheme
+        chunking: String,
+
+        #[structopt(
+            long,
+            validator = validate_chunk_size,
+            default_value = "128K"
+        )]
+        /// Set average chunk size
+        chunk_size: String,
+
+        #[structopt(
+            long,
+            possible_values = &["curve25519", "none"],
+            default_value = "curve25519"
+        )]
+        /// Set encryptiopn scheme
+        encryption: String,
+
+        #[structopt(
+            long,
+            possible_values = &["deflate", "xz2", "zstd", "bzip2", "none"],
+            default_value = "zstd"
+        )]
+        /// Set compression scheme
+        compression: String,
+
+        #[structopt(long, default_value = "0")]
+        /// Set compression level where negative numbers mean "faster" and positive ones "smaller"
+        compression_level: i32,
+
+        #[structopt(long, validator = validate_nesting, default_value = "2")]
+        /// Set level of folder nesting
+        nesting: u8,
+
+        #[structopt(
+            long,
+            possible_values = &["sha256", "blake2b"],
+            default_value = "blake2b"
+        )]
+        /// Set hashing scheme
+        hashing: String,
+    },
+
+    #[structopt(display_order = 1)]
+    /// Store data to repository
+    Store {
+        /// Name to store to
+        name: String,
+    },
+
+    #[structopt(display_order = 2)]
+    /// Load data from repository
+    Load {
+        /// Name to load from
+        name: String,
+    },
+
+    #[structopt(display_order = 3, visible_alias = "ls")]
+    /// List names stored in the repository
+    List,
+
+    #[structopt(display_order = 4, visible_alias = "rm")]
+    /// Remove name(s) stored in the repository
+    Remove {
+        /// Names to remove
+        names: Vec<String>,
+    },
+
+    #[structopt(
+        display_order = 5,
+        name = "change_passphrase",
+        visible_alias = "chpasswd"
+    )]
+    /// Change the passphrase protecting the encryption key (if any)
+    ChangePassphrase,
+
+    #[structopt(display_order = 6)]
+    /// Garbage collect unreferenced chunks
+    Gc {
+        #[structopt(long = "grace", default_value = "86400")]
+        /// Set grace time in seconds
+        grace_time: u64,
+    },
+
+    #[structopt(display_order = 7)]
+    /// Verify integrity of data stored in the repository
+    Verify {
+        /// Name(s) to verify
+        names: Vec<String>,
+    },
+
+    #[structopt(display_order = 8)]
+    /// Calculate disk usage due to the data stored for a set of names
+    Du {
+        /// Name(s) to check
+        names: Vec<String>,
+    },
+}
+
+fn run() -> io::Result<()> {
+    let cli_opts = CliOpts::from_args();
+
+    let url: Url = if let Some(loc) = cli_opts.repo_uri {
+        let s = loc.into_string().map_err(|_| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("URI not valid UTF-8 string"),
             )
         })?;
         parse_url(&s)?
-    } else if let Some(dir) = matches.value_of_os("REPO_DIR") {
-        Url::from_file_path(dir).map_err(|_| {
+    } else if let Some(dir) = cli_opts.repo_dir {
+        Url::from_file_path(&dir).map_err(|_| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("URI parsing error: {}", dir.to_string_lossy()),
@@ -414,34 +508,35 @@ fn run() -> io::Result<()> {
     let mut options = Options::new(url);
 
     let log = create_logger(
-        matches.occurrences_of("VERBOSE") as u32,
-        matches.occurrences_of("VERBOSE_TIMINGS") as u32,
+        cli_opts.verbose.len() as u32,
+        cli_opts.verbose_timings.len() as u32,
     );
 
-    match matches.subcommand() {
-        ("init", Some(matches)) => {
-            options.set_chunking(
-                matches.value_of("CHUNKING").unwrap(),
-                matches
-                    .value_of("CHUNK_SIZE")
-                    .map(|s| {
-                        util::parse_size(s).expect("Invalid chunk size option")
-                    })
-                    .map(|u| u.trailing_zeros()),
+    match cli_opts.command {
+        Command::Init {
+            chunking,
+            chunk_size,
+            encryption,
+            pwhash,
+            compression,
+            compression_level,
+            nesting,
+            hashing,
+        } => {
+            let chunk_size = Some(
+                util::parse_size(&chunk_size)
+                    .expect("Invalid chunk size option")
+                    .trailing_zeros(),
             );
-            options.set_encryption(matches.value_of("ENCRYPTION").unwrap());
-            options.settings.set_pwhash(settings::PWHash::from(
-                matches.value_of("PWHASH").unwrap(),
-            ));
-            options.set_compression(matches.value_of("COMPRESSION").unwrap());
-            options.settings.set_compression_level(
-                i32::from_str(matches.value_of("COMPRESSION_LEVEL").unwrap())
-                    .expect("invalid compression level"),
-            );
-            options.set_nesting(
-                u8::from_str(matches.value_of("NESTING").unwrap()).unwrap(),
-            );
-            options.set_hashing(matches.value_of("HASHING").unwrap());
+            options.set_chunking(&chunking, chunk_size);
+            options.set_encryption(&encryption);
+            options
+                .settings
+                .set_pwhash(settings::PWHash::from(pwhash.as_str()));
+            options.set_compression(&compression);
+            options.settings.set_compression_level(compression_level);
+            options.set_nesting(nesting);
+            options.set_hashing(&hashing);
             let _ = Repo::init(
                 &options.url,
                 &|| util::read_new_passphrase(),
@@ -449,62 +544,57 @@ fn run() -> io::Result<()> {
                 log,
             )?;
         }
-        ("store", Some(matches)) => {
-            let name = matches.value_of("NAME").expect("name agument missing");
+        Command::Store { name } => {
             let repo = Repo::open(&options.url, log)?;
             let enc = repo.unlock_encrypt(&|| util::read_passphrase())?;
-            let stats = repo.write(name, &mut io::stdin(), &enc)?;
+            let stats = repo.write(&name, &mut io::stdin(), &enc)?;
             println!("{} new chunks", stats.new_chunks);
             println!("{} new bytes", stats.new_bytes);
         }
-        ("load", Some(matches)) => {
-            let name = matches.value_of("NAME").expect("name agument missing");
+        Command::Load { name } => {
             let repo = Repo::open(&options.url, log)?;
             let dec = repo.unlock_decrypt(&|| util::read_passphrase())?;
-            repo.read(name, &mut io::stdout(), &dec)?;
+            repo.read(&name, &mut io::stdout(), &dec)?;
         }
-        ("change_passphrase", Some(_matches)) => {
+        Command::ChangePassphrase => {
             let mut repo = Repo::open(&options.url, log)?;
             repo.change_passphrase(&|| read_passphrase(), &|| {
                 read_new_passphrase()
             })?;
         }
-        ("remove", Some(matches)) => {
+        Command::Remove { names } => {
             let repo = Repo::open(&options.url, log)?;
-            for name in matches.values_of("NAME").expect("names missing") {
-                repo.rm(name)?;
+            for name in names {
+                repo.rm(&name)?;
             }
         }
-        ("du", Some(matches)) => {
+        Command::Du { names } => {
             let repo = Repo::open(&options.url, log)?;
             let dec = repo.unlock_decrypt(&|| read_passphrase())?;
 
-            for name in matches.values_of("NAME").expect("names missing") {
-                let result = repo.du(name, &dec)?;
+            for name in names {
+                let result = repo.du(&name, &dec)?;
                 println!("{} chunks", result.chunks);
                 println!("{} bytes", result.bytes);
             }
         }
-        ("gc", Some(matches)) => {
-            let grace_secs = u64::from_str(
-                matches.value_of("GRACE_TIME").unwrap(),
-            ).expect("invalid grace time");
+        Command::Gc { grace_time } => {
             let repo = Repo::open(&options.url, log)?;
 
-            repo.gc(grace_secs)?;
+            repo.gc(grace_time)?;
         }
-        ("list", Some(_matches)) => {
+        Command::List => {
             let repo = Repo::open(&options.url, log)?;
 
             for name in repo.list_names()? {
                 println!("{}", name);
             }
         }
-        ("verify", Some(matches)) => {
+        Command::Verify { names } => {
             let repo = Repo::open(&options.url, log)?;
             let dec = repo.unlock_decrypt(&|| read_passphrase())?;
-            for name in matches.values_of("NAME").expect("values") {
-                let results = repo.verify(name, &dec)?;
+            for name in names {
+                let results = repo.verify(&name, &dec)?;
                 println!("scanned {} chunk(s)", results.scanned);
                 println!("found {} corrupted chunk(s)", results.errors.len());
                 for err in results.errors {
@@ -512,7 +602,6 @@ fn run() -> io::Result<()> {
                 }
             }
         }
-        _ => panic!("Unrecognized subcommand"),
     }
 
     Ok(())


### PR DESCRIPTION
Implements #173 to use `structopt` for argument parsing. I had put these changes together a few days ago, and was unaware of future integration of `structopt` into `clap`. So another PR will follow which builds on this PR but switches back to `clap` `v3.0.0-beta.1`.

Note that due to what I believe is currently a [bug](https://github.com/TeXitoi/structopt/issues/418) in `structopt`, the help text for the `remove` command lists the `rm` alias twice:

```
    remove               Remove names stored in the repository [aliases: rm, rm]
```

Otherwise, I believe the new changes produce consistent usage to the existing.