### PR TITLE
Implement `created` for `Metadata`

### DIFF
--- a/lib/src/aio/b2.rs
+++ b/lib/src/aio/b2.rs
@@ -203,6 +203,7 @@ impl BackendThread for B2Thread {
     }
 
     fn read_metadata(&mut self, path: PathBuf) -> io::Result<Metadata> {
+        use chrono::TimeZone;
         let file_info: MoreFileInfo<serde_json::value::Value> =
             retry(Some(self), || {
                 self.auth
@@ -216,12 +217,15 @@ impl BackendThread for B2Thread {
         let MoreFileInfo {
             content_length,
             action,
+            upload_timestamp,
             ..
         } = file_info;
+        let created = chrono::Utc.timestamp(upload_timestamp as i64, 0);
 
-        Ok(super::Metadata {
-            _len: content_length,
-            _is_file: action == backblaze_b2::raw::files::FileType::File,
+        Ok(Metadata {
+            len: content_length,
+            is_file: action == backblaze_b2::raw::files::FileType::File,
+            created,
         })
     }
 

--- a/lib/src/aio/b2.rs
+++ b/lib/src/aio/b2.rs
@@ -7,7 +7,7 @@ use std::sync::mpsc;
 use std::{fs, io};
 
 use backblaze_b2::raw::authorize::{B2Authorization, B2Credentials};
-use backblaze_b2::raw::files::FileNameListing;
+use backblaze_b2::raw::files::{FileNameListing, MoreFileInfo};
 use backblaze_b2::raw::upload::UploadAuthorization;
 use backblaze_b2::B2Error;
 use hyper::net::HttpsConnector;
@@ -203,7 +203,26 @@ impl BackendThread for B2Thread {
     }
 
     fn read_metadata(&mut self, path: PathBuf) -> io::Result<Metadata> {
-        unimplemented!();
+        let file_info: MoreFileInfo<serde_json::value::Value> =
+            retry(Some(self), || {
+                self.auth
+                    .borrow_mut()
+                    .as_ref()
+                    .unwrap()
+                    .auth
+                    .get_file_info(&path.to_string_lossy(), &self.client)
+            })?;
+
+        let MoreFileInfo {
+            content_length,
+            action,
+            ..
+        } = file_info;
+
+        Ok(super::Metadata {
+            _len: content_length,
+            _is_file: action == backblaze_b2::raw::files::FileType::File,
+        })
     }
 
     fn list(&mut self, path: PathBuf) -> io::Result<Vec<PathBuf>> {

--- a/lib/src/aio/mod.rs
+++ b/lib/src/aio/mod.rs
@@ -34,6 +34,7 @@ struct WriteArgs {
 pub struct Metadata {
     pub len: u64,
     pub is_file: bool,
+    pub(crate) created: chrono::DateTime<chrono::Utc>,
 }
 
 /// A result of async io operation

--- a/lib/src/name.rs
+++ b/lib/src/name.rs
@@ -11,11 +11,14 @@ use crate::{DataAddress, DataAddressRef, Generation};
 
 pub(crate) const NAME_SUBDIR: &str = "name";
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct Name {
     #[serde(serialize_with = "as_hex", deserialize_with = "from_hex")]
     pub(crate) digest: Vec<u8>,
     pub(crate) index_level: u32,
+    #[serde(serialize_with = "as_rfc3339", deserialize_with = "from_rfc3339")]
+    /// The UTC timestamp when this `Name` was created.
+    pub(crate) created: chrono::DateTime<chrono::Utc>,
 }
 
 // TODO: I am very displeased with myself how this
@@ -25,6 +28,11 @@ pub(crate) struct Name {
 // Smells badly, but oh well...
 // -- dpc
 impl Name {
+    /// The UTC timestamp when this `Name` was created.
+    pub(crate) fn created(&self) -> chrono::DateTime<chrono::Utc> {
+        self.created
+    }
+
     pub(crate) fn remove(
         name: &str,
         gen: Generation,
@@ -145,23 +153,63 @@ impl Name {
         Ok(())
     }
 
+    /// Attempts to deserialize `path` as a `Name`. For backwards compatibility, if the source `Name`
+    /// does not have populated `created` information, populates from filesystem metadata.
+    fn try_deserialize(
+        name_str: &str,
+        gen: Generation,
+        aio: &aio::AsyncIO,
+    ) -> Result<Name, io::Error> {
+        let path = Name::path(name_str, gen);
+
+        let config_data = aio.read(path.clone()).wait()?;
+        let config_data = config_data.to_linear_vec();
+
+        if let Ok(name) = serde_yaml::from_reader(config_data.as_slice()) {
+            return Ok(name); // Ok-rewrap for change in Result Error type
+        }
+
+        #[derive(Debug, Deserialize)]
+        /// Legacy version of `Name` missing `created` field
+        struct NameLegacyV3 {
+            #[serde(deserialize_with = "from_hex")]
+            digest: Vec<u8>,
+            index_level: u32,
+        }
+
+        let NameLegacyV3 {
+            digest,
+            index_level,
+        } = dbg!(serde_yaml::from_reader(config_data.as_slice())).map_err(
+            |e| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("couldn't parse yaml: {}", e.to_string()),
+                )
+            },
+        )?;
+
+        let created = aio.read_metadata(path.clone()).wait()?.created;
+
+        let name = Name {
+            digest,
+            index_level,
+            created,
+        };
+
+        // re-write the `Name` configuration to include the `created` field.
+        if let Err(_) = name.write_as(name_str, gen, aio) {
+            // FIXME: log the write error?
+        }
+        Ok(name)
+    }
+
     pub fn load_from(
         name: &str,
         gen: Generation,
         aio: &aio::AsyncIO,
     ) -> io::Result<Self> {
-        let path = Name::path(name, gen);
-
-        let config_data = aio.read(path).wait()?;
-        let config_data = config_data.to_linear_vec();
-
-        let name: Name = serde_yaml::from_reader(config_data.as_slice())
-            .map_err(|e| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!("couldn't parse yaml: {}", e.to_string()),
-                )
-            })?;
+        let name = Name::try_deserialize(name, gen, aio)?;
 
         if name.digest.len() != DIGEST_SIZE {
             return Err(io::Error::new(
@@ -197,6 +245,7 @@ impl<'a> From<DataAddressRef<'a>> for Name {
         Name {
             digest: da.digest.0.into(),
             index_level: da.index_level,
+            created: chrono::Utc::now(),
         }
     }
 }
@@ -206,6 +255,7 @@ impl From<DataAddress> for Name {
         Name {
             digest: da.digest.0,
             index_level: da.index_level,
+            created: chrono::Utc::now(),
         }
     }
 }


### PR DESCRIPTION
Implements field `created` for `Metadata` for #176 use.

* Implements for both `Local` and `B2` `Backends`. However, `B2` backend is untested (I do not use)
* Currently errors if the `read_metadata` implementation cannot provide either `created` or `modified` values. These are utilized to support backwards compatibility, to fill in the `Name.created` value when it is not present in the configuration file.
* With this implementation, if a `Name` is deserialized without a `created` value, it is populated from filesystem data and the configuration file re-written. **This may not work appropriately with the `lock_shared` semantics of "read" operations?**
* If the `write` operation fails when attempting to update a legacy `Name` configuration to include `created` information, the error is **silently ignored**. This is to avoid breaking, e.g., somebody trying to read legacy configurations from a read-only system for restoration, etc. This should at least, however, be logged, but current implementation does not pass a `Logger`.