### PR TITLE
Make AIO backend API available

### DIFF
--- a/lib/src/aio/b2.rs
+++ b/lib/src/aio/b2.rs
@@ -22,7 +22,7 @@ use crate::config;
 
 // TODO: make a thread, that keeps updating
 // a timestamp file on the backend
-struct Lock {
+pub struct Lock {
     path: PathBuf,
 }
 
@@ -35,17 +35,17 @@ impl Lock {
 impl aio::Lock for Lock {}
 
 #[derive(Debug)]
-pub(crate) struct B2 {
+pub struct B2 {
     cred: B2Credentials,
     bucket: String,
 }
 
-struct Auth {
+pub struct Auth {
     auth: B2Authorization,
     upload_auth: UploadAuthorization,
 }
 
-struct B2Thread {
+pub struct B2Thread {
     cred: B2Credentials,
     auth: RefCell<Option<Auth>>,
     client: Client,

--- a/lib/src/aio/backend.rs
+++ b/lib/src/aio/backend.rs
@@ -7,13 +7,13 @@ use sgdata::SGData;
 /// A lock held on the backend
 ///
 /// It doesn't do much, except unlock on `drop`.
-pub(crate) trait Lock {}
+pub trait Lock {}
 
 /// Backend API
 ///
 /// Backend is thread-safe, and the actual work
 /// is implemented by per-thread instances of it.
-pub(crate) trait Backend: Send + Sync {
+pub trait Backend: Send + Sync {
     /// Lock the repository exclusively
     ///
     /// Use to protect operations that are potentially destructive,
@@ -29,7 +29,7 @@ pub(crate) trait Backend: Send + Sync {
     fn new_thread(&self) -> io::Result<Box<dyn BackendThread>>;
 }
 
-pub(crate) trait BackendThread: Send {
+pub trait BackendThread: Send {
     fn remove_dir_all(&mut self, path: PathBuf) -> io::Result<()>;
 
     fn rename(

--- a/lib/src/aio/local.rs
+++ b/lib/src/aio/local.rs
@@ -23,12 +23,12 @@ pub(crate) fn lock_file_path(path: &Path) -> PathBuf {
 }
 
 #[derive(Debug)]
-pub(crate) struct Local {
+pub struct Local {
     path: PathBuf,
 }
 
 #[derive(Debug)]
-struct LocalThread {
+pub struct LocalThread {
     path: PathBuf,
     rand_ext: String,
 }
@@ -64,7 +64,7 @@ impl Backend for Local {
 }
 
 impl Local {
-    pub(crate) fn new(path: PathBuf) -> Self {
+    pub fn new(path: PathBuf) -> Self {
         Local { path }
     }
 }
@@ -151,8 +151,8 @@ impl BackendThread for LocalThread {
         let path = self.path.join(path);
         let md = fs::metadata(&path)?;
         Ok(Metadata {
-            _len: md.len(),
-            _is_file: md.is_file(),
+            len: md.len(),
+            is_file: md.is_file(),
         })
     }
 

--- a/lib/src/aio/mod.rs
+++ b/lib/src/aio/mod.rs
@@ -7,18 +7,19 @@ use std::sync::{Arc, Mutex};
 use std::{io, thread};
 
 use dangerous_option::DangerousOption as AutoOption;
+use serde::{Deserialize, Serialize};
 use sgdata::SGData;
 use slog::{o, trace};
 use slog::{Level, Logger};
 use slog_perf::TimeReporter;
 use url::Url;
 
-mod local;
+pub(crate) mod local;
 pub(crate) use self::local::Local;
-mod b2;
+pub(crate) mod b2;
 pub(crate) use self::b2::B2;
 
-mod backend;
+pub(crate) mod backend;
 use self::backend::*;
 
 // {{{ Misc
@@ -29,9 +30,10 @@ struct WriteArgs {
     complete_tx: Option<mpsc::Sender<io::Result<()>>>,
 }
 
-pub(crate) struct Metadata {
-    _len: u64,
-    _is_file: bool,
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Metadata {
+    pub len: u64,
+    pub is_file: bool,
 }
 
 /// A result of async io operation


### PR DESCRIPTION
Hello,
as I've announced in advance, I'm offering a small code refactoring.

While the `rdedup_lib` internals are well-ready for a new backend being implemented, currently one has to implement it directly to the `rdedup_lib` which is not very handy. This PR changes this - it only makes some necessary structs and traits visible so anyone can implement a new backend into his own code and use `redup_lib` as it is, only as a dependency.  
An example how the usage will look like afterward can be seen here: [`RemoteBackend`](https://github.com/jendakol/rbackup2-poc/blob/master/client/src/remote.rs) and [its usage](https://github.com/jendakol/rbackup2-poc/blob/master/client/src/main.rs#L29) (please mind/excuse its PoC status).

The API is exposed via some [artificial modules](https://github.com/jendakol/rdedup/blob/84aa1764db6c968c7f7fd63c9c8467a0e9a30616/lib/src/lib.rs#L60). The reason is that exposing them with their real _nestings_ would IMHO look confusing to a newcomer and, on the other hand, refactoring it to follow these artificial modules structure would be much bigger cut to the library - maybe worth it though. It's up to you, of course.

Thanks for your great work :handshake: 