### PR TITLE
Fix build error with clap v3 beta, bump to latest beta.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ members = [ "tester" ]
 [dependencies]
 # Default features disabled so they can be explicitly opted into
 rdedup-lib = { version = "3.1.0", path = "lib", default-features = false }
-clap = "=3.0.0-beta.1"
+clap = "=3.0.0-beta.2"
 log = "0.4.11"
 hex = "0.4.2"
 rpassword = "4.0"

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -316,12 +316,12 @@ fn create_logger(verbosity: u32, timing_verbosity: u32) -> slog::Logger {
 #[derive(Debug, Clap)]
 #[clap(author, about = "Data deduplication toolkit")]
 struct CliOpts {
-    #[clap(name = "dir", short = "d", long, value_name = "PATH")]
+    #[clap(name = "dir", short = 'd', long, value_name = "PATH")]
     /// Path to rdedup repository. Override `RDEDUP_DIR` environment variable
     repo_dir: Option<std::ffi::OsString>,
 
     #[clap(
-        short = "u",
+        short = 'u',
         long = "repo",
         conflicts_with = "dir",
         value_name = "URI"
@@ -329,11 +329,11 @@ struct CliOpts {
     /// Rdedup repository URI. Override the `RDEDUP_URI` environment variable
     repo_uri: Option<std::ffi::OsString>,
 
-    #[clap(short = "v", parse(from_occurrences))]
+    #[clap(short = 'v', parse(from_occurrences))]
     /// Increase debugging level for general messages
     verbose: u8,
 
-    #[clap(short = "t", parse(from_occurrences))]
+    #[clap(short = 't', parse(from_occurrences))]
     /// Increase debugging level for timings
     verbose_timings: u8,
 


### PR DESCRIPTION
I was unable to build rdedup from git master with rust v1.50.0  (x86_64-unknown-linux-gnu).  This PR fixes that for me and passes cursory testing.  I'm not sure what broke this previously, however!