### PR TITLE
Make the Backblaze B2 backend optional in the lib

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -16,12 +16,14 @@ name = "rdedup_lib"
 path = "src/lib.rs"
 
 [features]
-default = ["with-bzip2","with-deflate","with-xz2","with-zstd"]
+default = ["with-bzip2", "with-deflate", "with-xz2", "with-zstd", "backend-b2"]
 # Optional compression features
 with-bzip2 = ["bzip2"]
 with-deflate = ["flate2"]
 with-xz2 = ["rust-lzma"]
 with-zstd = ["zstd"]
+# Optional backends
+backend-b2 = ["backblaze-b2", "hyper", "hyper-native-tls"]
 
 [dependencies]
 rdedup-cdc = "0.1.0"
@@ -47,9 +49,9 @@ digest = "0.9.0"
 bytevec = "0.2"
 chrono = { version = "0.4", features = ["serde"] }
 url = "1"
-backblaze-b2 = "0.1"
-hyper = "0.10"
-hyper-native-tls = "0.3"
+backblaze-b2 = { version = "0.1", optional = true }
+hyper = { version = "0.10", optional = true }
+hyper-native-tls = { version = "0.3", optional = true }
 serde_json = "1"
 
 bzip2 = { version = "0.4.1", optional = true }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -65,6 +65,7 @@ pub mod backends {
         pub use crate::aio::local::{Local, LocalThread};
     }
 
+    #[cfg(feature = "backend-b2")]
     pub mod b2 {
         pub use crate::aio::b2::{Auth, B2Thread, Lock, B2};
     }


### PR DESCRIPTION
Hi,

I'm currently working on a project where I'm using `rdedup_lib` as a de-duplicating mechanism for a cache, and because of that I don't need any backend besides the local one.

In this PR I've made the Backblaze B2 backend optional through the `backend-b2` feature flag, which I've also added to the default set of features.

Since the standard error mechanism returns an `std::io::Error`, which isn't very descriptive, I opted for panicking when the requested backend isn't enabled.

**Note: I haven't actually tested the success and failure path of `rdedup_lib::aio::backend_from_url` as I don't actually use `rdedup`, nor do I have access to Backblaze B2.**